### PR TITLE
dulwich: fix output of `describe`(#4)

### DIFF
--- a/scmrepo/git/__init__.py
+++ b/scmrepo/git/__init__.py
@@ -314,7 +314,7 @@ class Git(Base):
     _stash_push = partialmethod(_backend_func, "_stash_push")
     _stash_apply = partialmethod(_backend_func, "_stash_apply")
     _stash_drop = partialmethod(_backend_func, "_stash_drop")
-    describe = partialmethod(_backend_func, "describe")
+    _describe = partialmethod(_backend_func, "_describe")
     diff = partialmethod(_backend_func, "diff")
     reset = partialmethod(_backend_func, "reset")
     checkout_index = partialmethod(_backend_func, "checkout_index")
@@ -397,3 +397,18 @@ class Git(Base):
 
     def _reset(self) -> None:
         self.backends.reset_all()
+
+    def describe(
+        self,
+        rev: str,
+        base: Optional[str] = None,
+        match: Optional[str] = None,
+        exclude: Optional[str] = None,
+    ) -> Optional[str]:
+        if (
+            base == "refs/heads"
+            and self.get_rev() == rev
+            and self.get_ref("HEAD", follow=False).startswith(base)
+        ):
+            return self.get_ref("HEAD", follow=False)
+        return self._describe(rev, base, match, exclude)

--- a/scmrepo/git/backend/base.py
+++ b/scmrepo/git/backend/base.py
@@ -278,7 +278,7 @@ class BaseGitBackend(ABC):
         """Drop the specified stash revision."""
 
     @abstractmethod
-    def describe(
+    def _describe(
         self,
         rev: str,
         base: Optional[str] = None,

--- a/scmrepo/git/backend/dulwich/__init__.py
+++ b/scmrepo/git/backend/dulwich/__init__.py
@@ -590,7 +590,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         except ValueError as exc:
             raise SCMError("Failed to drop stash entry") from exc
 
-    def describe(
+    def _describe(
         self,
         rev: str,
         base: Optional[str] = None,

--- a/scmrepo/git/backend/gitpython.py
+++ b/scmrepo/git/backend/gitpython.py
@@ -552,7 +552,7 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
         except GitCommandError:
             self.remove_ref(ref)
 
-    def describe(
+    def _describe(
         self,
         rev: str,
         base: Optional[str] = None,

--- a/scmrepo/git/backend/pygit2.py
+++ b/scmrepo/git/backend/pygit2.py
@@ -459,7 +459,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
 
         self.repo.stash_drop(index)
 
-    def describe(
+    def _describe(
         self,
         rev: str,
         base: Optional[str] = None,

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -607,3 +607,30 @@ def test_checkout_subdir(tmp_dir: TmpDir, scm: Git, git: Git):
     with (tmp_dir / "dir").chdir():
         git.checkout(rev)
         assert not (tmp_dir / "dir" / "bar").exists()
+
+
+@pytest.mark.skip_git_backend("pygit2", "gitpython")
+def test_describe(tmp_dir: TmpDir, scm: Git, git: Git):
+    tmp_dir.gen({"foo": "foo"})
+    scm.add_commit("foo", message="foo")
+    rev_foo = scm.get_rev()
+
+    tmp_dir.gen({"foo": "bar"})
+    scm.add_commit("foo", message="bar")
+    rev_bar = scm.get_rev()
+
+    assert git.describe(rev_foo, "refs/heads") is None
+
+    scm.checkout("branch", create_new=True)
+    assert git.describe(rev_bar, "refs/heads") == "refs/heads/branch"
+
+    tmp_dir.gen({"foo": "foobar"})
+    scm.add_commit("foo", message="foobar")
+    rev_foobar = scm.get_rev()
+
+    scm.checkout("master")
+    assert git.describe(rev_bar, "refs/heads") == "refs/heads/master"
+    assert git.describe(rev_foobar, "refs/heads") == "refs/heads/branch"
+
+    scm.tag("tag")
+    assert git.describe(rev_bar) == "refs/tags/tag"


### PR DESCRIPTION
fix: #4 and https://github.com/iterative/dvc/issues/6051
In dvc we get a random toggling branch name in `exp show`. It is because
when we iter branches the `dulwich.refs.keys` gives an unordered `Set`
of refs. Here we reordered it, and makes current active branch always be
in the first order.

1. Add order to the result of dulwich.refs.keys.
2. Make active branch always in the first place.
3. Add a new test to it.