### PR TITLE
`get_ref`: Fix annotated tags

### DIFF
--- a/scmrepo/git/backend/dulwich/__init__.py
+++ b/scmrepo/git/backend/dulwich/__init__.py
@@ -334,6 +334,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             raise SCMError(f"Failed to set '{name}'")
 
     def get_ref(self, name, follow: bool = True) -> Optional[str]:
+        from dulwich.objects import Tag
         from dulwich.refs import parse_symref_value
 
         name_b = os.fsencode(name)
@@ -350,6 +351,8 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             except ValueError:
                 pass
         if ref:
+            if ref in self.repo and isinstance(self.repo[ref], Tag):
+                ref = self.repo.get_peeled(name_b)
             return os.fsdecode(ref)
         return None
 

--- a/scmrepo/git/backend/pygit2.py
+++ b/scmrepo/git/backend/pygit2.py
@@ -317,13 +317,20 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
             )
 
     def get_ref(self, name, follow: bool = True) -> Optional[str]:
-        from pygit2 import GIT_REF_SYMBOLIC
+        from pygit2 import GIT_OBJ_COMMIT, GIT_REF_SYMBOLIC, Tag
 
         ref = self.repo.references.get(name)
         if not ref:
             return None
         if follow and ref.type == GIT_REF_SYMBOLIC:
             ref = ref.resolve()
+        try:
+            obj = self.repo[ref.target]
+            if isinstance(obj, Tag):
+                return str(obj.peel(GIT_OBJ_COMMIT).id)
+        except ValueError:
+            pass
+
         return str(ref.target)
 
     def remove_ref(self, name: str, old_ref: Optional[str] = None):

--- a/tests/test_dulwich.py
+++ b/tests/test_dulwich.py
@@ -1,9 +1,5 @@
 import pytest
 from pytest_mock import MockerFixture
-from pytest_test_utils import TmpDir
-
-from scmrepo.git import Git
-from scmrepo.git.backend.dulwich import DulwichBackend
 
 
 @pytest.mark.parametrize(
@@ -30,21 +26,3 @@ def test_dulwich_github_compat(mocker: MockerFixture, algorithm: bytes):
     strings = iter((b"ssh-rsa", key_data))
     packet.get_string = lambda: next(strings)
     _process_public_key_ok_gh(auth, None, None, packet)
-
-
-def test_dulwich_get_ref(tmp_dir: TmpDir, scm: Git):
-    backend = DulwichBackend(tmp_dir)
-    tmp_dir.gen("foo", "foo")
-    scm.add_commit("foo", message="foo")
-
-    scm.set_ref("refs/exp/base", "refs/heads/master")
-
-    custom_ref = backend.get_ref("refs/exp/base", follow=False)
-    assert str(custom_ref).rstrip("\n") == "refs/heads/master"
-
-    head = scm.get_rev()
-    tag = "my_tag"
-    scm.tag(["-a", tag, "-m", "Annotated Tag"])
-
-    tag_ref = backend.get_ref(f"refs/tags/{tag}", follow=False)
-    assert head == tag_ref

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -217,6 +217,8 @@ def test_get_ref(tmp_dir: TmpDir, scm: Git, git: Git):
 
     assert init_rev == git.get_ref("refs/foo/bar")
     assert init_rev == git.get_ref("refs/foo/baz")
+    assert init_rev == git.get_ref("refs/tags/annotated", follow=True)
+    assert init_rev == git.get_ref("refs/tags/annotated", follow=False)
     assert git.get_ref("refs/foo/baz", follow=False) == "refs/heads/master"
     assert git.get_ref("refs/foo/qux") is None
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -214,6 +214,7 @@ def test_get_ref(tmp_dir: TmpDir, scm: Git, git: Git):
             ): "ref: refs/heads/master",
         }
     )
+    scm.tag(["-a", "annotated", "-m", "Annotated Tag"])
 
     assert init_rev == git.get_ref("refs/foo/bar")
     assert init_rev == git.get_ref("refs/foo/baz")


### PR DESCRIPTION
Fixes `get_ref` for annotated tags.

Closes iterative/dvc#6383


From https://github.com/iterative/dvc/pull/7008