### PR TITLE
Add a new function last_n_commits (#12)

### DIFF
--- a/scmrepo/git/__init__.py
+++ b/scmrepo/git/__init__.py
@@ -322,6 +322,7 @@ class Git(Base):
     merge = partialmethod(_backend_func, "merge")
     validate_git_remote = partialmethod(_backend_func, "validate_git_remote")
     check_ref_format = partialmethod(_backend_func, "check_ref_format")
+    last_n_commits = partialmethod(_backend_func, "last_n_commits")
 
     def branch_revs(
         self, branch: str, end_rev: Optional[str] = None

--- a/scmrepo/git/backend/base.py
+++ b/scmrepo/git/backend/base.py
@@ -363,3 +363,16 @@ class BaseGitBackend(ABC):
     @abstractmethod
     def validate_git_remote(self, url: str, **kwargs):
         """Verify that url is a valid git URL or remote name."""
+
+    @abstractmethod
+    def last_n_commits(
+        self, rev: Optional[str] = None, max_count: Optional[int] = None
+    ) -> Iterable[str]:
+        """
+        Return a list of commit rev with a depth representing the history
+        of a given ref/commit
+        Args:
+            rev: Git revision as baseline, if `None` then `HEAD` as baseline.
+            max_count: is the maximum number of commits to fetch. If `None`
+                then it will return the whole history of commits.
+        """

--- a/scmrepo/git/backend/dulwich/__init__.py
+++ b/scmrepo/git/backend/dulwich/__init__.py
@@ -680,3 +680,12 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         from dulwich.refs import check_ref_format
 
         return check_ref_format(refname.encode())
+
+    def last_n_commits(
+        self, rev: Optional[str] = None, max_count: Optional[int] = None
+    ) -> Iterable[str]:
+        if not rev:
+            rev = self.get_rev()
+
+        gen = self.repo.get_walker(os.fsencode(rev), max_entries=max_count)
+        return [os.fsdecode(entry.commit.id) for entry in gen]

--- a/scmrepo/git/backend/gitpython.py
+++ b/scmrepo/git/backend/gitpython.py
@@ -645,3 +645,14 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
     def validate_git_remote(self, url: str, **kwargs):
         raise NotImplementedError
+
+    def last_n_commits(
+        self, rev: Optional[str] = None, max_count: Optional[int] = None
+    ) -> Iterable[str]:
+        if not rev:
+            rev = self.get_rev()
+
+        return [
+            c.hexsha
+            for c in self.repo.iter_commits(rev=rev, max_count=max_count)
+        ]

--- a/scmrepo/git/backend/pygit2.py
+++ b/scmrepo/git/backend/pygit2.py
@@ -596,3 +596,8 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
 
     def validate_git_remote(self, url: str, **kwargs):
         raise NotImplementedError
+
+    def last_n_commits(
+        self, rev: Optional[str] = None, max_count: Optional[int] = None
+    ) -> Iterable[str]:
+        raise NotImplementedError


### PR DESCRIPTION
fix: #12

used in iterative/dvc#5489.

1. Add a new function returning a list of commit rev with a depth
representing the history of a given ref/commit.
2. Implement `gitpython` and `dulwich` backends.
3. Add a new unit test for it.