### PR TITLE
fs: support root_marker

### DIFF
--- a/scmrepo/fs.py
+++ b/scmrepo/fs.py
@@ -59,7 +59,7 @@ class GitFileSystem(AbstractFileSystem):
 
     def _get_key(self, path: str) -> Tuple[str, ...]:
         relparts = path.split(self.sep)
-        if relparts == ["."]:
+        if relparts == [self.root_marker]:
             return ()
         return tuple(relparts)
 

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -82,7 +82,7 @@ def test_walk(tmp_dir: TmpDir, scm: Git):
             for root, dirs, nondirs in walk_results
         ]
 
-    assert convert_to_sets(fs.walk(".")) == convert_to_sets(
+    assert convert_to_sets(fs.walk("")) == convert_to_sets(
         [
             ("", ["data"], []),
             ("data", ["subdir"], []),
@@ -116,8 +116,8 @@ def test_ls(tmp_dir: TmpDir, scm: Git):
     scm.add_commit(files, message="add")
     fs = scm.get_fs("master")
 
-    assert fs.ls(".", detail=False) == ["foo", "тест", "data"]
-    assert fs.ls(".") == {
+    assert fs.ls("", detail=False) == ["foo", "тест", "data"]
+    assert fs.ls("") == {
         "data": {
             "mode": 16384,
             "name": "data",

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -126,7 +126,7 @@ def test_walk_with_submodules(
     files = []
     dirs = []
     fs = scm.get_fs("HEAD")
-    for _, dnames, fnames in fs.walk("."):
+    for _, dnames, fnames in fs.walk(""):
         dirs.extend(dnames)
         files.extend(fnames)
 


### PR DESCRIPTION
fsspec filesystems don't yet have a notion of cwd, so "." should not be used.
Instead, we should support using fs.root_marker ("" in our case), which is
currently broken.