### PR TITLE
pygit2: fix posixpath conversion from windows on is_ignored

### DIFF
--- a/scmrepo/git/backend/pygit2.py
+++ b/scmrepo/git/backend/pygit2.py
@@ -291,7 +291,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
     def is_ignored(self, path: "Union[str, os.PathLike[str]]") -> bool:
         rel = relpath(path, self.root_dir)
         if os.name == "nt":
-            rel.replace("\\", "/")
+            rel = rel.replace("\\", "/")
         return self.repo.path_is_ignored(rel)
 
     def set_ref(

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -720,9 +720,6 @@ def test_ignore(tmp_dir: TmpDir, scm: Git, git: Git):
 
 
 def test_ignored(tmp_dir: TmpDir, scm: Git, git: Git, git_backend: str):
-    if os.name == "nt" and git_backend == "pygit2":
-        pytest.skip()
-
     tmp_dir.gen({"dir1": {"file1.jpg": "cont", "file2.txt": "cont"}})
     tmp_dir.gen({".gitignore": "dir1/*.jpg"})
 


### PR DESCRIPTION
When we were converting windows path to posixpath, the values
were not in effect because we were not setting it to the
variable.

Also fixes #11, which unskips  on Windows + pygit2 backend, which
was due to the above bug.