### PR TITLE
dulwich/pygit: implement backend clone

### DIFF
--- a/scmrepo/git/__init__.py
+++ b/scmrepo/git/__init__.py
@@ -115,11 +115,20 @@ class Git(Base):
         return Stash(self)
 
     @classmethod
-    def clone(cls, url, to_path, **kwargs):
+    def clone(
+        cls,
+        url: str,
+        to_path: str,
+        rev: Optional[str] = None,
+        **kwargs,
+    ):
         for _, backend in GitBackends.DEFAULT.items():
             try:
                 backend.clone(url, to_path, **kwargs)
-                return Git(to_path)
+                repo = cls(to_path)
+                if rev:
+                    repo.checkout(rev)
+                return repo
             except NotImplementedError:
                 pass
         raise NoGitBackendError("clone")

--- a/scmrepo/git/backend/base.py
+++ b/scmrepo/git/backend/base.py
@@ -49,7 +49,6 @@ class BaseGitBackend(ABC):
     def clone(
         url: str,
         to_path: str,
-        rev: Optional[str] = None,
         shallow_branch: Optional[str] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
     ):

--- a/scmrepo/git/backend/dulwich/__init__.py
+++ b/scmrepo/git/backend/dulwich/__init__.py
@@ -133,7 +133,6 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def clone(
         url: str,
         to_path: str,
-        rev: Optional[str] = None,
         shallow_branch: Optional[str] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
     ):

--- a/scmrepo/git/backend/gitpython.py
+++ b/scmrepo/git/backend/gitpython.py
@@ -143,7 +143,6 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def clone(
         url: str,
         to_path: str,
-        rev: Optional[str] = None,
         shallow_branch: Optional[str] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
     ):
@@ -188,19 +187,6 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
             tmp_repo.close()
         except GitCommandError as exc:  # pylint: disable=no-member
             raise CloneError(url, to_path) from exc
-
-        # NOTE: using our wrapper to make sure that env is fixed in __init__
-        repo = GitPythonBackend(to_path)
-
-        if rev:
-            try:
-                repo.checkout(rev)
-            except GitCommandError as exc:  # pylint: disable=no-member
-                raise RevError(
-                    "failed to access revision '{}' for repo '{}'".format(
-                        rev, url
-                    )
-                ) from exc
 
     @staticmethod
     def init(path: str, bare: bool = False) -> None:

--- a/scmrepo/git/backend/pygit2.py
+++ b/scmrepo/git/backend/pygit2.py
@@ -150,7 +150,6 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
     def clone(
         url: str,
         to_path: str,
-        rev: Optional[str] = None,
         shallow_branch: Optional[str] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
     ):

--- a/scmrepo/git/backend/pygit2.py
+++ b/scmrepo/git/backend/pygit2.py
@@ -17,7 +17,12 @@ from typing import (
 
 from funcy import cached_property
 
-from scmrepo.exceptions import MergeConflictError, RevError, SCMError
+from scmrepo.exceptions import (
+    CloneError,
+    MergeConflictError,
+    RevError,
+    SCMError,
+)
 from scmrepo.utils import relpath
 
 from ..objects import GitCommit, GitObject
@@ -153,7 +158,14 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         shallow_branch: Optional[str] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
     ):
-        raise NotImplementedError
+        from pygit2 import GitError, clone_repository
+
+        if shallow_branch:
+            raise NotImplementedError
+        try:
+            clone_repository(url, to_path)
+        except GitError as exc:
+            raise CloneError(url, to_path) from exc
 
     @staticmethod
     def init(path: str, bare: bool = False) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ zip_safe = False
 packages = find:
 install_requires=
     gitpython>3
-    dulwich>=0.20.23
+    dulwich>=0.20.34
     pygit2>=1.5.0
     pygtrie>=2.3.2
     fsspec>=2021.7.0

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -883,3 +883,17 @@ async def test_git_ssh(
     assert git.get_ref("refs/heads/master") == rev
     scm.checkout("master")
     assert (tmp_dir / "foo").read_text() == "foo"
+
+
+def test_clone(
+    tmp_dir: TmpDir, scm: Git, git: Git, tmp_dir_factory: TempDirFactory
+):
+    tmp_dir.gen("foo", "foo")
+    scm.add_commit("foo", message="init")
+    rev = scm.get_rev()
+
+    target_dir = tmp_dir_factory.mktemp("git-clone")
+    git.clone(str(tmp_dir), (target_dir))
+    target = Git(str(target_dir))
+    assert target.get_rev() == rev
+    assert (target_dir / "foo").read_text() == "foo"

--- a/tests/test_scmrepo.py
+++ b/tests/test_scmrepo.py
@@ -11,8 +11,10 @@ from scmrepo.progress import GitProgressEvent
 def test_clone(tmp_dir: TmpDir, matcher: Type[Matcher]):
     progress = MagicMock()
     url = "https://github.com/iterative/dvcyaml-schema"
+    rev = "cf279597596b54c5b0ce089eb4bda41ebbbb5db4"
 
-    Git.clone(url, "dir", progress=progress)
+    repo = Git.clone(url, "dir", rev=rev, progress=progress)
+    assert repo.get_rev() == rev
 
     progress.assert_called_with(matcher.instance_of(GitProgressEvent))
     assert (tmp_dir / "dir").exists()

--- a/tests/test_scmrepo.py
+++ b/tests/test_scmrepo.py
@@ -18,3 +18,13 @@ def test_clone(tmp_dir: TmpDir, matcher: Type[Matcher]):
 
     progress.assert_called_with(matcher.instance_of(GitProgressEvent))
     assert (tmp_dir / "dir").exists()
+
+
+def test_clone_shallow(tmp_dir: TmpDir):
+    url = "https://github.com/iterative/dvcyaml-schema"
+    shallow_branch = "master"
+
+    repo = Git.clone(url, "dir", shallow_branch=shallow_branch)
+    shallow_file = tmp_dir / "dir" / ".git" / "shallow"
+    assert shallow_file.exists()
+    assert repo.get_rev() in shallow_file.read_text().splitlines()


### PR DESCRIPTION
- Moves `Git.clone(rev=...)` checkout handling out of backend `clone()` and into `Git.clone()`. Separating this behavior allows us to use `clone()` from one backend and `checkout()` from another, since some backends may implement one but not the other.
- Implements clone in dulwich backend ~~(pending fix for https://github.com/dulwich/dulwich/issues/920)~~
- Implements clone in pygit backend (shallow clone not supported)

Will close https://github.com/iterative/dvc/issues/2215