### PR TITLE
pygit2: resolve_rev raise a proper exception with `~<n>` like referen…

### DIFF
--- a/scmrepo/git/backend/pygit2.py
+++ b/scmrepo/git/backend/pygit2.py
@@ -317,9 +317,17 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
             )
 
     def get_ref(self, name, follow: bool = True) -> Optional[str]:
-        from pygit2 import GIT_OBJ_COMMIT, GIT_REF_SYMBOLIC, Tag
+        from pygit2 import (
+            GIT_OBJ_COMMIT,
+            GIT_REF_SYMBOLIC,
+            InvalidSpecError,
+            Tag,
+        )
 
-        ref = self.repo.references.get(name)
+        try:
+            ref = self.repo.references.get(name)
+        except InvalidSpecError:
+            return None
         if not ref:
             return None
         if follow and ref.type == GIT_REF_SYMBOLIC:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -571,12 +571,16 @@ def test_resolve_rev(
     assert git.resolve_rev("refs/foo") == rev
     assert git.resolve_rev("bar") == rev
     assert git.resolve_rev("origin/baz") == rev
+    assert git.resolve_rev("HEAD~1") == init_rev
 
     with pytest.raises(RevError):
         git.resolve_rev("qux")
 
     with pytest.raises(RevError):
         git.resolve_rev("baz")
+
+    with pytest.raises(RevError):
+        git.resolve_rev("HEAD~3")
 
 
 @pytest.mark.skip_git_backend("dulwich")


### PR DESCRIPTION
fix: #30
Current pygit2 backend's resolve_rev didn't raise a proper exception when dealing with
`HEAD~n` like references.

1. Catch the exception in resolve_rev and reraise it into a proper format.
2. Add a test for it.


In `resolve_refish` both `HEAD~n` like references and `non-exist` references raise a ValueError, can't distinguish them. And I don't think we should let Inner exception `InvalidSpecError` be thrown outside of `scmrepo`. But this method is a relatively slow one, because we need to iter over all of the remotes.