### PR TITLE
Solve `pygit2` version conflict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires=
     gitpython>3
     dulwich>=0.20.34
-    pygit2>=1.5.0
+    pygit2>=1.6.0
     pygtrie>=2.3.2
     fsspec>=2021.7.0
     pathspec>=0.9.0,<0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires=
     gitpython>3
     dulwich>=0.20.34
-    pygit2>=1.6.0
+    pygit2>=1.7.2
     pygtrie>=2.3.2
     fsspec>=2021.7.0
     pathspec>=0.9.0,<0.10.0


### PR DESCRIPTION
In version 1.5.0, I got a 
> ImportError: cannot import name 'GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY' from 'pygit2'

`GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY` was introduced in 1.6.0. Upgrade the min version of `pygit2` to fix it.