### PR TITLE
pygit: update to 1.7.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires=
     gitpython>3
     dulwich>=0.20.34
-    pygit2>=1.5.0
+    pygit2>=1.7.2
     pygtrie>=2.3.2
     fsspec>=2021.7.0
     pathspec>=0.9.0,<0.10.0


### PR DESCRIPTION
- scmrepo actually requires 1.6.0 now due to the clone/merge changes (caught by @karajan1001), but 1.7.2 also adds support for the universal mac wheels