### PR TITLE
Update on push_refspec and fetch_refspec (#58)

### DIFF
--- a/scmrepo/git/__init__.py
+++ b/scmrepo/git/__init__.py
@@ -348,7 +348,7 @@ class Git(Base):
     iter_refs = partialmethod(_backend_func, "iter_refs")
     iter_remote_refs = partialmethod(_backend_func, "iter_remote_refs")
     get_refs_containing = partialmethod(_backend_func, "get_refs_containing")
-    push_refspec = partialmethod(_backend_func, "push_refspec")
+    push_refspecs = partialmethod(_backend_func, "push_refspecs")
     fetch_refspecs = partialmethod(_backend_func, "fetch_refspecs")
     _stash_iter = partialmethod(_backend_func, "_stash_iter")
     _stash_push = partialmethod(_backend_func, "_stash_push")

--- a/scmrepo/git/backend/base.py
+++ b/scmrepo/git/backend/base.py
@@ -28,7 +28,7 @@ class NoGitBackendError(SCMError):
 
 class SyncStatus(Enum):
     SUCCESS = 0
-    DUPLICATED = 1
+    UP_TO_DATE = 1
     DIVERGED = 2
 
 
@@ -226,7 +226,7 @@ class BaseGitBackend(ABC):
 
         Args:
             url: Git remote name or absolute Git URL.
-            refspecs: Iterable containing refspecs to fetch.
+            refspecs: Iterable containing refspecs to push.
                 Note that this will not match subkeys.
             force: If True, remote refs will be overwritten.
             on_diverged: Callback function which will be called if local ref

--- a/scmrepo/git/backend/base.py
+++ b/scmrepo/git/backend/base.py
@@ -1,5 +1,6 @@
 import os
 from abc import ABC, abstractmethod
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -23,6 +24,12 @@ if TYPE_CHECKING:
 class NoGitBackendError(SCMError):
     def __init__(self, func):
         super().__init__(f"No valid Git backend for '{func}'")
+
+
+class SyncStatus(Enum):
+    SUCCESS = 0
+    DUPLICATED = 1
+    DIVERGED = 2
 
 
 class BaseGitBackend(ABC):
@@ -206,25 +213,21 @@ class BaseGitBackend(ABC):
         """Iterate over all git refs containing the specified revision."""
 
     @abstractmethod
-    def push_refspec(
+    def push_refspecs(
         self,
         url: str,
-        src: Optional[str],
-        dest: str,
+        refspecs: Union[str, Iterable[str]],
         force: bool = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
-    ):
+    ) -> Mapping[str, SyncStatus]:
         """Push refspec to a remote Git repo.
 
         Args:
             url: Git remote name or absolute Git URL.
-            src: Local refspec. If src ends with "/" it will be treated as a
-                prefix, and all refs inside src will be pushed using dest
-                as destination refspec prefix. If src is None, dest will be
-                deleted from the remote.
-            dest: Remote refspec.
+            refspecs: Iterable containing refspecs to fetch.
+                Note that this will not match subkeys.
             force: If True, remote refs will be overwritten.
             on_diverged: Callback function which will be called if local ref
                 and remote have diverged and force is False. If the callback
@@ -237,12 +240,12 @@ class BaseGitBackend(ABC):
     def fetch_refspecs(
         self,
         url: str,
-        refspecs: Iterable[str],
-        force: Optional[bool] = False,
+        refspecs: Union[str, Iterable[str]],
+        force: bool = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
-    ):
+    ) -> Mapping[str, SyncStatus]:
         """Fetch refspecs from a remote Git repo.
 
         Args:

--- a/scmrepo/git/backend/dulwich/__init__.py
+++ b/scmrepo/git/backend/dulwich/__init__.py
@@ -528,7 +528,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
                 refname = os.fsdecode(rh)
                 if rh in refs and lh is not None:
                     if refs[rh] == self.repo.refs[lh]:
-                        change_result[refname] = SyncStatus.DUPLICATED
+                        change_result[refname] = SyncStatus.UP_TO_DATE
                         continue
                     try:
                         check_diverged(self.repo, refs[rh], self.repo.refs[lh])
@@ -632,7 +632,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             refname = os.fsdecode(rh)
             if rh in self.repo.refs:
                 if self.repo.refs[rh] == fetch_result.refs[lh]:
-                    result[refname] = SyncStatus.DUPLICATED
+                    result[refname] = SyncStatus.UP_TO_DATE
                     continue
                 try:
                     check_diverged(

--- a/scmrepo/git/backend/gitpython.py
+++ b/scmrepo/git/backend/gitpython.py
@@ -28,7 +28,7 @@ from scmrepo.exceptions import (
 from scmrepo.utils import relpath
 
 from ..objects import GitCommit, GitObject
-from .base import BaseGitBackend
+from .base import BaseGitBackend, SyncStatus
 
 if TYPE_CHECKING:
     from scmrepo.progress import GitProgressEvent
@@ -474,27 +474,26 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
         except GitCommandError:
             pass
 
-    def push_refspec(
+    def push_refspecs(
         self,
         url: str,
-        src: Optional[str],
-        dest: str,
+        refspecs: Union[str, Iterable[str]],
         force: bool = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
-    ):
+    ) -> Mapping[str, SyncStatus]:
         raise NotImplementedError
 
     def fetch_refspecs(
         self,
         url: str,
-        refspecs: Iterable[str],
-        force: Optional[bool] = False,
+        refspecs: Union[str, Iterable[str]],
+        force: bool = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
-    ):
+    ) -> Mapping[str, SyncStatus]:
         raise NotImplementedError
 
     def _stash_iter(self, ref: str):

--- a/scmrepo/git/backend/pygit2.py
+++ b/scmrepo/git/backend/pygit2.py
@@ -26,7 +26,7 @@ from scmrepo.exceptions import (
 from scmrepo.utils import relpath
 
 from ..objects import GitCommit, GitObject
-from .base import BaseGitBackend
+from .base import BaseGitBackend, SyncStatus
 
 logger = logging.getLogger(__name__)
 
@@ -414,27 +414,26 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
             ) and _contains(self.repo, ref, search_commit):
                 yield ref
 
-    def push_refspec(
+    def push_refspecs(
         self,
         url: str,
-        src: Optional[str],
-        dest: str,
+        refspecs: Union[str, Iterable[str]],
         force: bool = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
-    ):
+    ) -> Mapping[str, SyncStatus]:
         raise NotImplementedError
 
     def fetch_refspecs(
         self,
         url: str,
-        refspecs: Iterable[str],
-        force: Optional[bool] = False,
+        refspecs: Union[str, Iterable[str]],
+        force: bool = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
-    ):
+    ) -> Mapping[str, SyncStatus]:
         raise NotImplementedError
 
     def _stash_iter(self, ref: str):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -327,7 +327,7 @@ def test_refs_containing(tmp_dir: TmpDir, scm: Git, git: Git):
 
 @pytest.mark.skip_git_backend("pygit2", "gitpython")
 @pytest.mark.parametrize("use_url", [True, False])
-def test_push_refspec(
+def test_push_refspecs(
     tmp_dir: TmpDir,
     scm: Git,
     git: Git,
@@ -356,10 +356,10 @@ def test_push_refspec(
     scm.gitpython.repo.create_remote("origin", url)
 
     with pytest.raises(SCMError):
-        git.push_refspec("bad-remote", "refs/foo/bar:refs/foo/bar")
+        git.push_refspecs("bad-remote", "refs/foo/bar:refs/foo/bar")
 
     remote = url if use_url else "origin"
-    assert git.push_refspec(remote, "refs/foo/bar:refs/foo/bar") == {
+    assert git.push_refspecs(remote, "refs/foo/bar:refs/foo/bar") == {
         "refs/foo/bar": SyncStatus.SUCCESS
     }
     assert bar_rev == remote_scm.get_ref("refs/foo/bar")
@@ -368,7 +368,7 @@ def test_push_refspec(
     assert bar_rev == remote_scm.get_rev()
     assert (remote_git_dir / "file").read_text() == "0"
 
-    assert git.push_refspec(
+    assert git.push_refspecs(
         remote, ["refs/foo/bar:refs/foo/bar", "refs/foo/baz:refs/foo/baz"]
     ) == {
         "refs/foo/bar": SyncStatus.DUPLICATED,
@@ -376,12 +376,12 @@ def test_push_refspec(
     }
     assert baz_rev == remote_scm.get_ref("refs/foo/baz")
 
-    assert git.push_refspec(remote, ["refs/foo/bar:refs/foo/baz"]) == {
+    assert git.push_refspecs(remote, ["refs/foo/bar:refs/foo/baz"]) == {
         "refs/foo/baz": SyncStatus.DIVERGED
     }
     assert baz_rev == remote_scm.get_ref("refs/foo/baz")
 
-    assert git.push_refspec(remote, ":refs/foo/baz") == {
+    assert git.push_refspecs(remote, ":refs/foo/baz") == {
         "refs/foo/baz": SyncStatus.SUCCESS
     }
     assert remote_scm.get_ref("refs/foo/baz") is None
@@ -905,10 +905,9 @@ async def test_git_ssh(
     scm.add_commit("foo", message="init")
     rev = scm.get_rev()
 
-    git.push_refspec(
+    git.push_refspecs(
         url,
-        "refs/heads/master",
-        "refs/heads/master",
+        "refs/heads/master:refs/heads/master",
         force=True,
         key_filename=key_filename,
     )

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -371,7 +371,7 @@ def test_push_refspecs(
     assert git.push_refspecs(
         remote, ["refs/foo/bar:refs/foo/bar", "refs/foo/baz:refs/foo/baz"]
     ) == {
-        "refs/foo/bar": SyncStatus.DUPLICATED,
+        "refs/foo/bar": SyncStatus.UP_TO_DATE,
         "refs/foo/baz": SyncStatus.SUCCESS,
     }
     assert baz_rev == remote_scm.get_ref("refs/foo/baz")
@@ -430,7 +430,7 @@ def test_fetch_refspecs(
     assert git.fetch_refspecs(
         remote, ["refs/foo/bar:refs/foo/bar", "refs/foo/baz:refs/foo/baz"]
     ) == {
-        "refs/foo/bar": SyncStatus.DUPLICATED,
+        "refs/foo/bar": SyncStatus.UP_TO_DATE,
         "refs/foo/baz": SyncStatus.SUCCESS,
     }
     assert baz_rev == scm.get_ref("refs/foo/baz")

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -334,13 +334,20 @@ def test_push_refspec(
     remote_git_dir: TmpDir,
     use_url: str,
 ):
+    from scmrepo.git.backend.dulwich import SyncStatus
+
     tmp_dir.gen({"file": "0"})
     scm.add_commit("file", message="init")
     init_rev = scm.get_rev()
+    scm.add_commit("file", message="bar")
+    bar_rev = scm.get_rev()
+    scm.checkout(init_rev)
+    scm.add_commit("file", message="baz")
+    baz_rev = scm.get_rev()
     tmp_dir.gen(
         {
-            os.path.join(".git", "refs", "foo", "bar"): init_rev,
-            os.path.join(".git", "refs", "foo", "baz"): init_rev,
+            os.path.join(".git", "refs", "foo", "bar"): bar_rev,
+            os.path.join(".git", "refs", "foo", "baz"): baz_rev,
         }
     )
 
@@ -349,53 +356,89 @@ def test_push_refspec(
     scm.gitpython.repo.create_remote("origin", url)
 
     with pytest.raises(SCMError):
-        git.push_refspec("bad-remote", "refs/foo/bar", "refs/foo/bar")
+        git.push_refspec("bad-remote", "refs/foo/bar:refs/foo/bar")
 
     remote = url if use_url else "origin"
-    git.push_refspec(remote, "refs/foo/bar", "refs/foo/bar")
-    assert init_rev == remote_scm.get_ref("refs/foo/bar")
+    assert git.push_refspec(remote, "refs/foo/bar:refs/foo/bar") == {
+        "refs/foo/bar": SyncStatus.SUCCESS
+    }
+    assert bar_rev == remote_scm.get_ref("refs/foo/bar")
 
     remote_scm.checkout("refs/foo/bar")
-    assert init_rev == remote_scm.get_rev()
+    assert bar_rev == remote_scm.get_rev()
     assert (remote_git_dir / "file").read_text() == "0"
 
-    git.push_refspec(remote, "refs/foo/", "refs/foo/")
-    assert init_rev == remote_scm.get_ref("refs/foo/baz")
+    assert git.push_refspec(
+        remote, ["refs/foo/bar:refs/foo/bar", "refs/foo/baz:refs/foo/baz"]
+    ) == {
+        "refs/foo/bar": SyncStatus.DUPLICATED,
+        "refs/foo/baz": SyncStatus.SUCCESS,
+    }
+    assert baz_rev == remote_scm.get_ref("refs/foo/baz")
 
-    git.push_refspec(remote, None, "refs/foo/baz")
+    assert git.push_refspec(remote, ["refs/foo/bar:refs/foo/baz"]) == {
+        "refs/foo/baz": SyncStatus.DIVERGED
+    }
+    assert baz_rev == remote_scm.get_ref("refs/foo/baz")
+
+    assert git.push_refspec(remote, ":refs/foo/baz") == {
+        "refs/foo/baz": SyncStatus.SUCCESS
+    }
     assert remote_scm.get_ref("refs/foo/baz") is None
 
 
 @pytest.mark.skip_git_backend("pygit2", "gitpython")
+@pytest.mark.parametrize("use_url", [True, False])
 def test_fetch_refspecs(
+    tmp_dir: TmpDir,
     scm: Git,
     git: Git,
     remote_git_dir: TmpDir,
+    use_url: bool,
 ):
-    url = f"file://{remote_git_dir.resolve().as_posix()}"
 
+    from scmrepo.git.backend.dulwich import SyncStatus
+
+    url = f"file://{remote_git_dir.resolve().as_posix()}"
+    scm.gitpython.repo.create_remote("origin", url)
     remote_scm = Git(remote_git_dir)
     remote_git_dir.gen("file", "0")
+
     remote_scm.add_commit("file", message="init")
-
     init_rev = remote_scm.get_rev()
-
+    remote_scm.add_commit("file", message="bar")
+    bar_rev = remote_scm.get_rev()
+    remote_scm.checkout(init_rev)
+    remote_scm.add_commit("file", message="baz")
+    baz_rev = remote_scm.get_rev()
     remote_git_dir.gen(
         {
-            os.path.join(".git", "refs", "foo", "bar"): init_rev,
-            os.path.join(".git", "refs", "foo", "baz"): init_rev,
+            os.path.join(".git", "refs", "foo", "bar"): bar_rev,
+            os.path.join(".git", "refs", "foo", "baz"): baz_rev,
         }
     )
 
-    git.fetch_refspecs(
-        url, ["refs/foo/bar:refs/foo/bar", "refs/foo/baz:refs/foo/baz"]
-    )
-    assert init_rev == scm.get_ref("refs/foo/bar")
-    assert init_rev == scm.get_ref("refs/foo/baz")
+    with pytest.raises(SCMError):
+        git.fetch_refspecs("bad-remote", "refs/foo/bar:refs/foo/bar")
 
-    remote_scm.checkout("refs/foo/bar")
-    assert init_rev == remote_scm.get_rev()
-    assert (remote_git_dir / "file").read_text() == "0"
+    remote = url if use_url else "origin"
+    assert git.fetch_refspecs(remote, "refs/foo/bar:refs/foo/bar") == {
+        "refs/foo/bar": SyncStatus.SUCCESS
+    }
+    assert bar_rev == scm.get_ref("refs/foo/bar")
+
+    assert git.fetch_refspecs(
+        remote, ["refs/foo/bar:refs/foo/bar", "refs/foo/baz:refs/foo/baz"]
+    ) == {
+        "refs/foo/bar": SyncStatus.DUPLICATED,
+        "refs/foo/baz": SyncStatus.SUCCESS,
+    }
+    assert baz_rev == scm.get_ref("refs/foo/baz")
+
+    assert git.fetch_refspecs(remote, ["refs/foo/bar:refs/foo/baz"]) == {
+        "refs/foo/baz": SyncStatus.DIVERGED
+    }
+    assert baz_rev == scm.get_ref("refs/foo/baz")
 
 
 @pytest.mark.skip_git_backend("dulwich", "pygit2")


### PR DESCRIPTION
fix: #58

1. Unify the API of `push_refspec` and  `fetch_refspec`.
2. Can push multi `refspec` for one time.
3. No repository Error handle for `fetch_refspec`
4. Now the `push_refspec` and  `fetch_refspec` will return the status for each refspec.