### PR TITLE
tests: bump paramiko to 2.10.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,10 +46,10 @@ dev =
     pylint==2.11.1
     mock==4.0.3
     mypy==0.910
-    paramiko==2.8.1
+    paramiko==2.10.0
     types-certifi==2021.10.8.0
     types-mock==4.0.13
-    types-paramiko==2.8.1
+    types-paramiko==2.10.0
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Tests on windows with python 3.10 result in:

```
___________________ ERROR collecting tests/test_dulwich.py ____________________
ImportError while importing test module 'D:\a\scmrepo\scmrepo\tests\test_dulwich.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\hostedtoolcache\windows\Python\3.10.4\x64\lib\importlib\__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests\test_dulwich.py:7: in <module>
    import paramiko
.nox\tests-3-10\lib\site-packages\paramiko\__init__.py:22: in <module>
    from paramiko.transport import SecurityOptions, Transport
.nox\tests-3-10\lib\site-packages\paramiko\transport.py:89: in <module>
    from paramiko.dsskey import DSSKey
.nox\tests-3-10\lib\site-packages\paramiko\dsskey.py:37: in <module>
    from paramiko.pkey import PKey
.nox\tests-3-10\lib\site-packages\paramiko\pkey.py:30: in <module>
    import six
E   ModuleNotFoundError: No module named 'six'
```

See https://github.com/paramiko/paramiko/pull/1985.