### PR TITLE
dulwich: update fetch_refspecs for dulwich 0.20.37

### DIFF
--- a/scmrepo/git/backend/dulwich/__init__.py
+++ b/scmrepo/git/backend/dulwich/__init__.py
@@ -581,7 +581,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         self,
         url: str,
         refspecs: Union[str, Iterable[str]],
-        force: Optional[bool] = False,
+        force: bool = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
         progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
@@ -597,12 +597,17 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
         fetch_refs = []
 
-        def determine_wants(remote_refs):
+        def determine_wants(
+            remote_refs: Dict[bytes, bytes],
+            depth: Optional[int] = None,  # pylint: disable=unused-argument
+        ) -> List[bytes]:
             fetch_refs.extend(
                 parse_reftuples(
                     remote_refs,
                     self.repo.refs,
-                    refspecs,
+                    os.fsencode(refspecs)
+                    if isinstance(refspecs, str)
+                    else [os.fsencode(refspec) for refspec in refspecs],
                     force=force,
                 )
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ zip_safe = False
 packages = find:
 install_requires=
     gitpython>3
-    dulwich>=0.20.34
+    dulwich>=0.20.37
     pygit2>=1.7.2
     pygtrie>=2.3.2
     fsspec>=2021.7.0


### PR DESCRIPTION
dulwich 0.20.37 updated type hints for `fetch` (see https://github.com/jelmer/dulwich/pull/957)

fixes #65 