### PR TITLE
ci: bump timeout to 15 minutes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: Tests
 on: [push, pull_request]
 jobs:
   tests:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
having 10 minutes was causing timeouts for Windows and MacOS