### PR TITLE
stash apply: support reinstate_index and skip_conflicts

### DIFF
--- a/scmrepo/git/backend/base.py
+++ b/scmrepo/git/backend/base.py
@@ -281,7 +281,13 @@ class BaseGitBackend(ABC):
         """
 
     @abstractmethod
-    def _stash_apply(self, rev: str):
+    def _stash_apply(
+        self,
+        rev: str,
+        reinstate_index: bool = False,
+        skip_conflicts: bool = False,
+        **kwargs,
+    ):
         """Apply the specified stash revision."""
 
     @abstractmethod

--- a/scmrepo/git/backend/dulwich/__init__.py
+++ b/scmrepo/git/backend/dulwich/__init__.py
@@ -695,7 +695,13 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             ) from exc
         return os.fsdecode(rev), True
 
-    def _stash_apply(self, rev: str):
+    def _stash_apply(
+        self,
+        rev: str,
+        reinstate_index: bool = False,
+        skip_conflicts: bool = False,
+        **kwargs,
+    ):
         raise NotImplementedError
 
     def _stash_drop(self, ref: str, index: int):

--- a/scmrepo/git/backend/gitpython.py
+++ b/scmrepo/git/backend/gitpython.py
@@ -528,11 +528,23 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
             self.git.stash("drop")
         return commit.hexsha, False
 
-    def _stash_apply(self, rev: str):
+    def _stash_apply(
+        self,
+        rev: str,
+        reinstate_index: bool = False,
+        skip_conflicts: bool = False,
+        **kwargs,
+    ):
         from git.exc import GitCommandError
 
+        if skip_conflicts:
+            raise NotImplementedError
         try:
-            self.git.stash("apply", rev)
+            args = ["apply"]
+            if reinstate_index:
+                args.append("--index")
+            args.append(rev)
+            self.git.stash(args)
         except GitCommandError as exc:
             out = str(exc)
             if "CONFLICT" in out or "already exists" in out:

--- a/tests/test_pygit2.py
+++ b/tests/test_pygit2.py
@@ -1,5 +1,6 @@
 import pygit2
 import pytest
+from pytest_mock import MockerFixture
 from pytest_test_utils import TmpDir
 
 from scmrepo.git import Git
@@ -30,3 +31,32 @@ def test_pygit_resolve_refish(tmp_dir: TmpDir, scm: Git, use_sha: str):
     assert str(commit.id) == head
     if not use_sha:
         assert ref.name == f"refs/tags/{tag}"
+
+
+@pytest.mark.parametrize("skip_conflicts", [True, False])
+def test_pygit_stash_apply_conflicts(
+    tmp_dir: TmpDir, scm: Git, skip_conflicts: bool, mocker: MockerFixture
+):
+    from pygit2 import GIT_CHECKOUT_ALLOW_CONFLICTS
+
+    tmp_dir.gen("foo", "foo")
+    scm.add_commit("foo", message="foo")
+    tmp_dir.gen("foo", "bar")
+    scm.stash.push()
+    rev = scm.resolve_rev(r"stash@{0}")
+
+    backend = Pygit2Backend(tmp_dir)
+    mock = mocker.patch.object(backend.repo, "stash_apply")
+    backend._stash_apply(  # pylint: disable=protected-access
+        rev, skip_conflicts=skip_conflicts
+    )
+    expected_strategy = (
+        backend._get_checkout_strategy()  # pylint: disable=protected-access
+    )
+    if skip_conflicts:
+        expected_strategy |= GIT_CHECKOUT_ALLOW_CONFLICTS
+    mock.assert_called_once_with(
+        0,
+        strategy=expected_strategy,
+        reinstate_index=False,
+    )


### PR DESCRIPTION
Adds support for `--index` and force-applying in `stash apply`

prereq for https://github.com/iterative/dvc/issues/6930
