### PR TITLE
Add mutli rev support for function `describe`

### DIFF
--- a/src/scmrepo/git/backend/base.py
+++ b/src/scmrepo/git/backend/base.py
@@ -297,12 +297,12 @@ class BaseGitBackend(ABC):
     @abstractmethod
     def _describe(
         self,
-        rev: str,
+        revs: Iterable[str],
         base: Optional[str] = None,
         match: Optional[str] = None,
         exclude: Optional[str] = None,
-    ) -> Optional[str]:
-        """Return the first ref which points to rev.
+    ) -> Mapping[str, Optional[str]]:
+        """Return the first ref which points to each revs.
 
         Roughly equivalent to `git describe --all --exact-match`.
 

--- a/src/scmrepo/git/backend/gitpython.py
+++ b/src/scmrepo/git/backend/gitpython.py
@@ -572,11 +572,11 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
     def _describe(
         self,
-        rev: str,
+        revs: Iterable[str],
         base: Optional[str] = None,
         match: Optional[str] = None,
         exclude: Optional[str] = None,
-    ) -> Optional[str]:
+    ) -> Mapping[str, Optional[str]]:
         raise NotImplementedError
 
     def diff(self, rev_a: str, rev_b: str, binary=False) -> str:

--- a/src/scmrepo/git/backend/pygit2.py
+++ b/src/scmrepo/git/backend/pygit2.py
@@ -515,11 +515,11 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
 
     def _describe(
         self,
-        rev: str,
+        revs: Iterable[str],
         base: Optional[str] = None,
         match: Optional[str] = None,
         exclude: Optional[str] = None,
-    ) -> Optional[str]:
+    ) -> Mapping[str, Optional[str]]:
         raise NotImplementedError
 
     def diff(self, rev_a: str, rev_b: str, binary=False) -> str:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -705,21 +705,28 @@ def test_describe(tmp_dir: TmpDir, scm: Git, git: Git):
     scm.add_commit("foo", message="bar")
     rev_bar = scm.get_rev()
 
-    assert git.describe(rev_foo, "refs/heads") is None
+    assert git.describe([rev_foo], "refs/heads") == {rev_foo: None}
 
     scm.checkout("branch", create_new=True)
-    assert git.describe(rev_bar, "refs/heads") == "refs/heads/branch"
+    assert git.describe([rev_bar], "refs/heads") == {
+        rev_bar: "refs/heads/branch"
+    }
 
     tmp_dir.gen({"foo": "foobar"})
     scm.add_commit("foo", message="foobar")
     rev_foobar = scm.get_rev()
 
     scm.checkout("master")
-    assert git.describe(rev_bar, "refs/heads") == "refs/heads/master"
-    assert git.describe(rev_foobar, "refs/heads") == "refs/heads/branch"
+    assert git.describe([rev_bar, rev_foobar], "refs/heads") == {
+        rev_bar: "refs/heads/master",
+        rev_foobar: "refs/heads/branch",
+    }
 
     scm.tag("tag")
-    assert git.describe(rev_bar) == "refs/tags/tag"
+    assert git.describe([rev_bar, "nonexist"]) == {
+        rev_bar: "refs/tags/tag",
+        "nonexist": None,
+    }
 
 
 def test_ignore(tmp_dir: TmpDir, scm: Git, git: Git):


### PR DESCRIPTION
fix: #144

In our current describe function we only accept one rev at a time and will try to get a reference for every reference in the repo. It will cost O(MN) in the `exp show` in which we try to get a ref for every single experiment.