### PR TITLE
add check_ref_format abstract method

### DIFF
--- a/src/scmrepo/git/backend/base.py
+++ b/src/scmrepo/git/backend/base.py
@@ -389,3 +389,7 @@ class BaseGitBackend(ABC):
     @abstractmethod
     def validate_git_remote(self, url: str, **kwargs):
         """Verify that url is a valid git URL or remote name."""
+
+    @abstractmethod
+    def check_ref_format(self, refname: str) -> bool:
+        """Check if a reference name is well formed."""

--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -858,7 +858,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         ):
             raise InvalidRemote(url)
 
-    def check_ref_format(self, refname: str):
+    def check_ref_format(self, refname: str) -> bool:
         from dulwich.refs import check_ref_format
 
         return check_ref_format(refname.encode())

--- a/src/scmrepo/git/backend/gitpython.py
+++ b/src/scmrepo/git/backend/gitpython.py
@@ -663,3 +663,6 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
     def validate_git_remote(self, url: str, **kwargs):
         raise NotImplementedError
+
+    def check_ref_format(self, refname: str):
+        raise NotImplementedError

--- a/src/scmrepo/git/backend/pygit2.py
+++ b/src/scmrepo/git/backend/pygit2.py
@@ -773,3 +773,6 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
 
     def validate_git_remote(self, url: str, **kwargs):
         raise NotImplementedError
+
+    def check_ref_format(self, refname: str):
+        raise NotImplementedError


### PR DESCRIPTION
adds dummy implementation for `pygit2` and `gitpython`

In some cases, switching backends (from dulwich) would result in `AttributeNotFoundError` due to missing implementation in `pygit2` and `gitpython`.