### PR TITLE
implement pygit2 backend for fetch_refspec

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires=
     pathspec>=0.9.0
     asyncssh>=2.7.1,<3
     funcy>=1.14
+    shortuuid>=0.5.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
implement pygit2 backend for fetch_refspec

fix #168 

Compare to the `cprofile` in https://github.com/iterative/dvc/issues/8477. 

The new greatly reduced the time cost in fetching.

![image](https://user-images.githubusercontent.com/6745454/212890306-481fd2b2-235a-41bc-a879-e8a563dcf7ea.png)

Making the total `dvc exp show` query finished in 1s. And brings a much smoother performance in vs-code extension.  And also solves the hanging problem in https://github.com/iterative/dvc/issues/8762

https://user-images.githubusercontent.com/6745454/212892100-ae2d032d-e23b-4b62-9207-28752a3de4c8.mp4

But we still had one problem remaining to solve, how to make `scmrepo` use the `pygit2` as the default backend. In the test and the demo, I simply raise `NotImplementError` in Dulwich to disable it. 
