### PR TITLE
codespaces: revert config workaround

### DIFF
--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -285,31 +285,9 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             try:
                 commit(self.root_dir, message=msg, no_verify=no_verify)
             except InvalidUserIdentity as exc:
-                identity = self._get_codespaces_identity()
-                if identity is not None:
-                    commit(
-                        self.root_dir,
-                        message=msg,
-                        no_verify=no_verify,
-                        committer=identity,
-                        author=identity,
-                    )
-                else:
-                    raise SCMError("Git username and email must be configured") from exc
+                raise SCMError("Git username and email must be configured") from exc
             except TimezoneFormatError as exc:
                 raise SCMError("Invalid Git timestamp") from exc
-
-    def _get_codespaces_identity(self) -> Optional[bytes]:
-        from dulwich.config import ConfigFile, StackedConfig
-        from dulwich.repo import get_user_identity
-
-        if "CODESPACES" not in os.environ:
-            return None
-        try:
-            config = StackedConfig([ConfigFile.from_path("/usr/local/etc/gitconfig")])
-            return get_user_identity(config)
-        except Exception:  # pylint: disable=broad-except
-            return None
 
     def checkout(
         self,

--- a/src/scmrepo/git/backend/pygit2.py
+++ b/src/scmrepo/git/backend/pygit2.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
 )
 
-from funcy import cached_property, first
+from funcy import cached_property
 
 from scmrepo.exceptions import CloneError, MergeConflictError, RevError, SCMError
 from scmrepo.utils import relpath
@@ -27,8 +27,6 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from pygit2 import Signature
-
     from scmrepo.progress import GitProgressEvent
 
 
@@ -120,29 +118,11 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         return commit, ref
 
     @property
-    def default_signature(self) -> "Signature":
+    def default_signature(self):
         try:
             return self.repo.default_signature
         except KeyError as exc:
-            signature = self._get_codespaces_signature()
-            if signature is not None:
-                return signature
             raise SCMError("Git username and email must be configured") from exc
-
-    def _get_codespaces_signature(self) -> Optional["Signature"]:
-        from pygit2 import Config, Signature
-
-        if "CODESPACES" not in os.environ:
-            return None
-        try:
-            config = Config("/usr/local/etc/gitconfig")
-            name = first(config.get_multivar("user.name"))
-            email = first(config.get_multivar("user.email"))
-            if name and email:
-                return Signature(name, email)
-        except Exception:  # nosec B110, pylint: disable=broad-except
-            pass
-        return None
 
     @staticmethod
     def _get_checkout_strategy(strategy: Optional[int] = None):


### PR DESCRIPTION
Codespaces git install appears to be fixed now, both github `/usr/local/bin/git` and system `/usr/bin/git` use `/etc/gitconfig` in the latest codespaces container
Closes https://github.com/iterative/scmrepo/issues/148