### PR TITLE
pin linuxserver/openssh-server image

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.2'
 services:
   git-server:
-    image: ghcr.io/linuxserver/openssh-server
+    image: ghcr.io/linuxserver/openssh-server:9.0_p1-r2-ls100
     environment:
       - USER_NAME=user
       - PUBLIC_KEY_FILE=/tmp/key


### PR DESCRIPTION
Need to further investigate why the recent version was causing failures on CI.

Looks like we can't rely on dependabot per https://github.com/dependabot/dependabot-core/issues/390