### PR TITLE
fetch_refspecs: Use `dulwich` for ssh urls.

### DIFF
--- a/src/scmrepo/git/__init__.py
+++ b/src/scmrepo/git/__init__.py
@@ -327,12 +327,18 @@ class Git(Base):
         progress: Optional[Callable[["GitProgressEvent"], None]] = None,
         **kwargs,
     ) -> typing.Mapping[str, SyncStatus]:
+        from urllib.parse import urlparse
+
         from .credentials import get_matching_helper_commands
 
-        if "dulwich" in kwargs.get("backends", self.backends.backends) and any(
-            get_matching_helper_commands(url, self.dulwich.repo.get_config_stack())
-        ):
-            kwargs["backends"] = ["dulwich"]
+        if "dulwich" in kwargs.get("backends", self.backends.backends):
+            credentials_helper = any(
+                get_matching_helper_commands(url, self.dulwich.repo.get_config_stack())
+            )
+            parsed = urlparse(url)
+            ssh = parsed.scheme in ("git", "git+ssh", "ssh") or url.startswith("git@")
+            if credentials_helper or ssh:
+                kwargs["backends"] = ["dulwich"]
 
         return self._fetch_refspecs(
             url,


### PR DESCRIPTION
Using pygit2 was causing https://github.com/iterative/dvc/issues/9080