### PR TITLE
dulwich: use `SubprocessSSHVendor` when necessary

### DIFF
--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -98,6 +98,8 @@ class DulwichProgressReporter(GitProgressReporter):
 
 
 def _get_ssh_vendor() -> "SSHVendor":
+    import sys
+
     from dulwich.client import SubprocessSSHVendor
 
     from .asyncssh_vendor import AsyncSSHVendor
@@ -105,6 +107,13 @@ def _get_ssh_vendor() -> "SSHVendor":
     ssh_command = os.environ.get("GIT_SSH_COMMAND", os.environ.get("GIT_SSH"))
     if ssh_command:
         logger.debug("dulwich: Using environment GIT_SSH_COMMAND '%s'", ssh_command)
+        return SubprocessSSHVendor()
+
+    if sys.platform == "win32" and os.environ.get("MSYSTEM"):
+        # see https://github.com/iterative/dvc/issues/7702
+        logger.debug(
+            "dulwich: native win32 Python inside MSYS2/git-bash, using MSYS2 OpenSSH"
+        )
         return SubprocessSSHVendor()
     return AsyncSSHVendor()
 

--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -102,7 +102,7 @@ def _get_ssh_vendor() -> "SSHVendor":
 
     from dulwich.client import SubprocessSSHVendor
 
-    from .asyncssh_vendor import AsyncSSHVendor
+    from .asyncssh_vendor import AsyncSSHVendor, get_unsupported_opts
 
     ssh_command = os.environ.get("GIT_SSH_COMMAND", os.environ.get("GIT_SSH"))
     if ssh_command:
@@ -113,6 +113,15 @@ def _get_ssh_vendor() -> "SSHVendor":
         # see https://github.com/iterative/dvc/issues/7702
         logger.debug(
             "dulwich: native win32 Python inside MSYS2/git-bash, using MSYS2 OpenSSH"
+        )
+        return SubprocessSSHVendor()
+
+    default_config = os.path.expanduser(os.path.join("~", ".ssh", "config"))
+    unsupported = list(get_unsupported_opts([default_config]))
+    if unsupported:
+        logger.debug(
+            "dulwich: unsupported SSH config option(s) '%s', using system OpenSSH",
+            ", ".join(unsupported),
         )
         return SubprocessSSHVendor()
     return AsyncSSHVendor()

--- a/tests/test_dulwich.py
+++ b/tests/test_dulwich.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import threading
 from io import StringIO
@@ -157,3 +158,16 @@ def test_dulwich_github_compat(mocker: MockerFixture, algorithm: bytes):
     strings = iter((b"ssh-rsa", key_data))
     packet.get_string = lambda: next(strings)
     _process_public_key_ok_gh(auth, None, None, packet)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows only")
+def test_git_bash_ssh_vendor(mocker):
+    from dulwich.client import SubprocessSSHVendor
+
+    from scmrepo.git.backend.dulwich import _get_ssh_vendor
+
+    mocker.patch.dict(os.environ, {"MSYSTEM": "MINGW64"})
+    assert isinstance(_get_ssh_vendor(), SubprocessSSHVendor)
+
+    mocker.patch.dict(os.environ, {"MSYSTEM": None})
+    assert isinstance(_get_ssh_vendor(), AsyncSSHVendor)


### PR DESCRIPTION
Falls back to using `SubprocessSSHVendor` instead of `AsyncSSHVendor` when:

- we are inside git-bash/msys environment on windows
- OpenSSH `~/.ssh/config` exists and contains options which are unsupported by asyncssh

Fixes: https://github.com/iterative/dvc/issues/7702
Related: https://github.com/iterative/dvc-ssh/issues/20

Closes https://github.com/iterative/scmrepo/issues/208
Closes https://github.com/iterative/scmrepo/pull/210