### PR TITLE
stash: handle clean workspace on push()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ module = [
     "pygtrie",
     "funcy",
     "git",
+    "gitdb.*",
     "fsspec.*",
     "pathspec.patterns",
     "asyncssh.*",

--- a/src/scmrepo/git/backend/base.py
+++ b/src/scmrepo/git/backend/base.py
@@ -261,7 +261,7 @@ class BaseGitBackend(ABC):
         self,
         ref: str,
         message: Optional[str] = None,
-        include_untracked: Optional[bool] = False,
+        include_untracked: bool = False,
     ) -> Tuple[Optional[str], bool]:
         """Push a commit onto the specified stash.
 

--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -672,11 +672,17 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         self,
         ref: str,
         message: Optional[str] = None,
-        include_untracked: Optional[bool] = False,
+        include_untracked: bool = False,
     ) -> Tuple[Optional[str], bool]:
         from dulwich.repo import InvalidUserIdentity
 
         from scmrepo.git import Stash
+
+        # dulwich will silently generate an empty stash commit if there is
+        # nothing to stash, we check status here to get consistent behavior
+        # across backends
+        if not self.is_dirty(untracked_files=include_untracked):
+            return None, False
 
         if include_untracked or ref == Stash.DEFAULT_STASH:
             # dulwich stash.push does not support include_untracked and does

--- a/src/scmrepo/git/backend/pygit2.py
+++ b/src/scmrepo/git/backend/pygit2.py
@@ -534,15 +534,19 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         self,
         ref: str,
         message: Optional[str] = None,
-        include_untracked: Optional[bool] = False,
+        include_untracked: bool = False,
     ) -> Tuple[Optional[str], bool]:
         from scmrepo.git import Stash
 
-        oid = self.repo.stash(
-            self.default_signature,
-            message=message,
-            include_untracked=include_untracked,
-        )
+        try:
+            oid = self.repo.stash(
+                self.default_signature,
+                message=message,
+                include_untracked=include_untracked,
+            )
+        except KeyError:
+            # GIT_ENOTFOUND, nothing to stash
+            return None, False
         commit = self.repo[oid]
 
         if ref != Stash.DEFAULT_STASH:

--- a/src/scmrepo/git/stash.py
+++ b/src/scmrepo/git/stash.py
@@ -32,14 +32,13 @@ class Stash:
     def push(
         self, message: Optional[str] = None, include_untracked: bool = False
     ) -> Optional[str]:
-        if not self.scm.is_dirty(untracked_files=include_untracked):
-            logger.debug("No changes to stash")
-            return None
-
         logger.debug("Stashing changes in '%s'", self.ref)
         rev, reset = self.scm._stash_push(  # pylint: disable=protected-access
             self.ref, message=message, include_untracked=include_untracked
         )
+        if not rev:
+            logger.debug("No changes to stash")
+            return None
         if reset:
             self.scm.reset(hard=True)
         return rev


### PR DESCRIPTION
Closes https://github.com/iterative/scmrepo/issues/211

- Clean workspace on stash.push is now handled properly for all backends
- When checking `is_dirty` or `status`, the check is done within the same backend, which eliminates inconsistencies when mixing status + stash calls across different backends

(This PR does not address the lack of gitattributes support in dulwich)