### PR TITLE
dulwich/pygit: support interactive username/pw auth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ module = [
     "asyncssh.*",
     "pygit2.*",
     "pytest_docker.plugin",
+    "urllib3.*",
 ]
 ignore_missing_imports = true
 

--- a/src/scmrepo/git/backend/dulwich/client.py
+++ b/src/scmrepo/git/backend/dulwich/client.py
@@ -1,6 +1,7 @@
-from typing import Optional
+import os
+from typing import Any, Dict, Optional
 
-from dulwich.client import Urllib3HttpGitClient
+from dulwich.client import HTTPUnauthorized, Urllib3HttpGitClient
 
 from scmrepo.git.credentials import Credential, CredentialNotFoundError
 
@@ -37,8 +38,51 @@ class GitCredentialsHTTPClient(Urllib3HttpGitClient):  # pylint: disable=abstrac
             self.pool_manager.headers.update(basic_auth)
             self._store_credentials = creds
 
-    def _http_request(self, *args, **kwargs):
-        result = super()._http_request(*args, **kwargs)
+    def _http_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]] = None,
+        data: Any = None,
+    ):
+        try:
+            result = super()._http_request(url, headers=headers, data=data)
+        except HTTPUnauthorized:
+            auth_header = self._get_auth()
+            if not auth_header:
+                raise
+            if headers:
+                headers.update(auth_header)
+            else:
+                headers = auth_header
+            result = super()._http_request(url, headers=headers, data=data)
         if self._store_credentials is not None:
             self._store_credentials.approve()
         return result
+
+    def _get_auth(self) -> Dict[str, str]:
+        from getpass import getpass
+
+        from urllib3.util import make_headers
+
+        try:
+            creds = Credential(username=self._username, url=self._base_url).fill()
+            self._store_credentials = creds
+            return make_headers(basic_auth=f"{creds.username}:{creds.password}")
+        except CredentialNotFoundError:
+            pass
+
+        if os.environ.get("GIT_TERMINAL_PROMPT") == "0":
+            return {}
+
+        try:
+            if self._username:
+                username = self._username
+            else:
+                username = input(f"Username for '{self._base_url}': ")
+            if self._password:
+                password = self._password
+            else:
+                password = getpass(f"Password for '{self._base_url}': ")
+            return make_headers(basic_auth=f"{username}:{password}")
+        except KeyboardInterrupt:
+            return {}


### PR DESCRIPTION
- Adds support for interactive username/password prompt
- Interactive support is disabled when `GIT_TERMINAL_PROMPT` env var is set to `0` (same as CLI Git)

dulwich changes:
- Now follows proper auth workflow for HTTP
    1. Unauthenticated request is tried first
    2. If request fails, credentials are read from credential helpers and interactive prompt (in that order)
    3. Request is retried with credentials from (2), if request fails, we raise the auth error
- asyncssh vendor now supports interactive prompt for username/password when the server requests it
    - Note that this is not always available depending on the server
    - Github/Gitlab/etc only allow key authentication over SSH
    - Mainly only useful for private/self-hosted git over SSH

pygit2 changes:
- Interactive username/pw auth supported for HTTP

(Note that SSH support is still disabled in pygit2 backend)