### PR TITLE
disallow cred helper to return empty output

### DIFF
--- a/src/scmrepo/git/credentials.py
+++ b/src/scmrepo/git/credentials.py
@@ -156,8 +156,6 @@ class GitCredentialHelper(CredentialHelper):
             raise CredentialNotFoundError("Helper not found") from exc
         if res.stderr:
             logger.debug(res.stderr)
-        if not res.stdout:
-            raise CredentialNotFoundError("No credentials found")
 
         credentials = {}
         for line in res.stdout.strip().splitlines():
@@ -166,6 +164,8 @@ class GitCredentialHelper(CredentialHelper):
                 credentials[key] = value
             except ValueError:
                 continue
+        if not credentials:
+            raise CredentialNotFoundError("No credentials found")
         return Credential(**credentials)
 
     def store(self, **kwargs):

--- a/src/scmrepo/git/credentials.py
+++ b/src/scmrepo/git/credentials.py
@@ -156,6 +156,8 @@ class GitCredentialHelper(CredentialHelper):
             raise CredentialNotFoundError("Helper not found") from exc
         if res.stderr:
             logger.debug(res.stderr)
+        if not res.stdout:
+            raise CredentialNotFoundError("No credentials found")
 
         credentials = {}
         for line in res.stdout.strip().splitlines():

--- a/src/scmrepo/git/credentials.py
+++ b/src/scmrepo/git/credentials.py
@@ -369,6 +369,11 @@ class Credential:
             self.username = self.username or parsed.username
             self.password = self.password or parsed.password
 
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Credential):
+            return self._helper_kwargs == other._helper_kwargs
+        return False
+
     @property
     def url(self) -> str:
         if self.username or self.password:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,64 @@
+import os
+
+import pytest
+
+from scmrepo.git.credentials import (
+    Credential,
+    CredentialNotFoundError,
+    GitCredentialHelper,
+)
+
+
+@pytest.fixture(name="helper")
+def helper_fixture(mocker) -> "GitCredentialHelper":
+    mocker.patch("shutil.which", return_value="/usr/bin/git-credential-foo")
+    return GitCredentialHelper("foo")
+
+
+def test_subprocess_get(helper, mocker):
+    run = mocker.patch(
+        "subprocess.run",
+        return_value=mocker.Mock(
+            stdout=os.linesep.join(
+                ["protocol=https", "host=foo.com", "username=foo", "password=bar", ""]
+            )
+        ),
+    )
+    creds = helper.get(protocol="https", host="foo.com")
+    assert run.call_args.args[0] == ["git-credential-foo", "get"]
+    assert run.call_args.kwargs.get("input") == os.linesep.join(
+        ["protocol=https", "host=foo.com", ""]
+    )
+    assert creds == Credential(url="https://foo:bar@foo.com")
+
+
+def test_subprocess_get_failed(helper, mocker):
+    from subprocess import CalledProcessError
+
+    mocker.patch("subprocess.run", side_effect=CalledProcessError(1, "/usr/bin/foo"))
+    with pytest.raises(CredentialNotFoundError):
+        helper.get(protocol="https", host="foo.com")
+
+
+def test_subprocess_get_no_output(helper, mocker):
+    mocker.patch("subprocess.run", return_value=mocker.Mock(stdout=os.linesep))
+    with pytest.raises(CredentialNotFoundError):
+        helper.get(protocol="https", host="foo.com")
+
+
+def test_subprocess_store(helper, mocker):
+    run = mocker.patch("subprocess.run")
+    helper.store(protocol="https", host="foo.com", username="foo", password="bar")
+    assert run.call_args.args[0] == ["git-credential-foo", "store"]
+    assert run.call_args.kwargs.get("input") == os.linesep.join(
+        ["protocol=https", "host=foo.com", "username=foo", "password=bar", ""]
+    )
+
+
+def test_subprocess_erase(helper, mocker):
+    run = mocker.patch("subprocess.run")
+    helper.erase(protocol="https", host="foo.com")
+    assert run.call_args.args[0] == ["git-credential-foo", "erase"]
+    assert run.call_args.kwargs.get("input") == os.linesep.join(
+        ["protocol=https", "host=foo.com", ""]
+    )


### PR DESCRIPTION
Continuing from https://github.com/iterative/scmrepo/pull/220#issuecomment-1489272094, the issue appears to be from having the cache helper enabled in my git config:

```
[credential]
	helper = cache
```

I get the prompt as expected when I disable this. However, when it's enabled, I don't get a prompt, even if I have no credentials cached. For example, this fails:

```
$ git credential-cache exit
$ dvc get -v https://github.com/dberenbaum/config-files vimrc
```

The credential helper does not fail but returns an empty output in this scenario.

I notice we don't have any tests for any of the credential helper logic. Do we need to add something?

I don't mind if you take this over @pmrowla, but once I found the issue it wasn't any extra work to submit the PR.