### PR TITLE
git.credentials: support UseHttpPath=true for credential helpers

### DIFF
--- a/src/scmrepo/git/backend/dulwich/client.py
+++ b/src/scmrepo/git/backend/dulwich/client.py
@@ -68,7 +68,8 @@ class GitCredentialsHTTPClient(Urllib3HttpGitClient):  # pylint: disable=abstrac
         from urllib3.util import make_headers
 
         try:
-            creds = Credential(username=self._username, url=self._base_url).fill()
+            base_url = self._base_url.rstrip("/")
+            creds = Credential(username=self._username, url=base_url).fill()
             self._store_credentials = creds
             return make_headers(basic_auth=f"{creds.username}:{creds.password}")
         except CredentialNotFoundError:

--- a/src/scmrepo/git/credentials.py
+++ b/src/scmrepo/git/credentials.py
@@ -176,9 +176,9 @@ class GitCredentialHelper(CredentialHelper):
             logger.debug(res.stderr)
 
         credentials = {}
-        for line in res.stdout.strip().splitlines():
+        for line in res.stdout.splitlines():
             try:
-                key, value = line.split("=")
+                key, value = line.split("=", maxsplit=1)
                 credentials[key] = value
             except ValueError:
                 continue
@@ -399,7 +399,8 @@ class MemoryCredentialHelper(CredentialHelper):
 
     def store(self, credential: "Credential", **kwargs):
         """Store the credential, if applicable to the helper"""
-        self[credential] = credential
+        if credential.protocol or credential.host or credential.path:
+            self[credential] = credential
 
     def erase(self, credential: "Credential", **kwargs):
         """Remove a matching credential, if any, from the helper’s storage"""
@@ -514,7 +515,7 @@ class Credential(Mapping[str, str]):
             self.username = self.username or parsed.username
             self.password = self.password or parsed.password
             if parsed.path:
-                self.path = self.path or parsed.path
+                self.path = self.path or parsed.path.lstrip("/")
 
     def __getitem__(self, key: object) -> str:
         if isinstance(key, str):

--- a/src/scmrepo/git/credentials.py
+++ b/src/scmrepo/git/credentials.py
@@ -493,6 +493,8 @@ class Credential(Mapping[str, str]):
             self.host = self.host or f"{hostname}{port}"
             self.username = self.username or parsed.username
             self.password = self.password or parsed.password
+            if parsed.path:
+                self.path = self.path or parsed.path
 
     def __getitem__(self, key: object) -> str:
         if isinstance(key, str):


### PR DESCRIPTION
see https://github.com/iterative/dvc/issues/9007

- adds support for AWS codecommit credential-helper