### PR TITLE
handle empty credential helper

### DIFF
--- a/src/scmrepo/git/credentials.py
+++ b/src/scmrepo/git/credentials.py
@@ -256,6 +256,8 @@ class GitCredentialHelper(CredentialHelper):
                 except KeyError:
                     # no helper configured
                     continue
+                if not command:
+                    continue
                 use_http_path = conf.get_boolean(section, "usehttppath", False)
                 yield (
                     command.decode(conf.encoding or sys.getdefaultencoding()),

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -201,3 +201,17 @@ def test_get_matching_commands():
     assert list(
         GitCredentialHelper.get_matching_commands("https://foo.com/foo.git", config)
     ) == [("/usr/local/bin/my-helper", False)]
+
+    config_file = io.BytesIO(
+        """
+[credential]
+    helper = 
+""".encode(
+            "ascii"
+        )
+    )
+    config_file.seek(0)
+    config = ConfigFile.from_file(config_file)
+    assert list(
+        GitCredentialHelper.get_matching_commands("https://foo.com/foo.git", config)
+    ) == []

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -205,13 +205,16 @@ def test_get_matching_commands():
     config_file = io.BytesIO(
         """
 [credential]
-    helper = 
+    helper =
 """.encode(
             "ascii"
         )
     )
     config_file.seek(0)
     config = ConfigFile.from_file(config_file)
-    assert list(
-        GitCredentialHelper.get_matching_commands("https://foo.com/foo.git", config)
-    ) == []
+    assert (
+        list(
+            GitCredentialHelper.get_matching_commands("https://foo.com/foo.git", config)
+        )
+        == []
+    )


### PR DESCRIPTION
Currently fails with a config like:

```
[credential]
	helper = 
```

I was using that to debug other auth issues by resetting my credential helpers and encountered an error.