### PR TITLE
temporarily disable pytest-docker entirely on py<3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ tests =
     pytest-test-utils==0.0.8
     pytest-asyncio==0.18.3
     # https://github.com/docker/docker-py/issues/2902
-    pytest-docker==0.12.0; python_version < '3.10' or sys_platform != 'win32'
+    pytest-docker==0.12.0; python_version < '3.10' and implementation_name != 'pypy'
     mock==5.0.1
     paramiko==3.1.0
     types-certifi==2021.10.8.3


### PR DESCRIPTION
pytest-docker deps cannot be pip installed on 3.10+ or on pypy. Issue is with pyyaml<6/Cython install (which comes from pytest-docker): https://github.com/yaml/pyyaml/issues/724

```
Collecting PyYAML<6,>=3.10 (from docker-compose<2.0,>=1.27.3->pytest-docker==0.12.0->scmrepo==1.0.5.dev4+gd3f663a)
```

see: https://github.com/iterative/scmrepo/actions/runs/5596450156/jobs/10233487390?pr=252