### PR TITLE
feat(pygit2): author and committer don't break if env is set and git conf is not

### DIFF
--- a/tests/test_pygit2.py
+++ b/tests/test_pygit2.py
@@ -1,9 +1,12 @@
 # pylint: disable=unused-argument
+import os
+
 import pygit2
 import pytest
 from pytest_mock import MockerFixture
 from pytest_test_utils import TmpDir
 
+from scmrepo.exceptions import SCMError
 from scmrepo.git import Git
 from scmrepo.git.backend.pygit2 import Pygit2Backend
 
@@ -68,8 +71,41 @@ def test_pygit_stash_apply_conflicts(
         "ssh://login@server.com:12345/repository.git",
     ],
 )
-def test_pygit2_ssh_error(tmp_dir: TmpDir, scm: Git, url):
+def test_pygit_ssh_error(tmp_dir: TmpDir, scm: Git, url):
     backend = Pygit2Backend(tmp_dir)
     with pytest.raises(NotImplementedError):
         with backend.get_remote(url):
             pass
+
+
+@pytest.mark.parametrize("name", ["committer", "author"])
+def test_pygit_use_env_vars_for_signature(
+    tmp_dir: TmpDir, mocker: MockerFixture, name: str
+):
+    from pygit2 import Signature
+
+    mocker.patch(
+        "scmrepo.git.Pygit2Backend.default_signature",
+        new=mocker.PropertyMock(side_effect=SCMError),
+    )
+    git = Git.init(tmp_dir)
+    with pytest.raises(SCMError):
+        git.pygit2.default_signature  # pylint: disable=W0104
+
+    # Make sure that the environment variables are not set to not interfere with
+    # with the check below
+    for var in [f"GIT_{name.upper()}_NAME", f"GIT_{name.upper()}_EMAIL"]:
+        assert os.environ.get(var, None) is None
+
+    # Basic expected behavior if vars are not set. Another sanity check
+    with pytest.raises(SCMError):
+        getattr(git.pygit2, name)
+
+    mocker.patch.dict(os.environ, {f"GIT_{name.upper()}_EMAIL": "olivaw@iterative.ai"})
+    with pytest.raises(SCMError):
+        getattr(git.pygit2, name)
+
+    mocker.patch.dict(os.environ, {f"GIT_{name.upper()}_NAME": "R. Daneel Olivaw"})
+    assert getattr(git.pygit2, name) == Signature(
+        email="olivaw@iterative.ai", name="R. Daneel Olivaw"
+    )


### PR DESCRIPTION
Fixes https://github.com/iterative/studio/issues/7185

PyGit2 (and our backend in scmrepo) throws an exception if there is no Git config set. Might be related to this https://github.com/libgit2/libgit2/issues/1528

Here we are trying to get env vars first, if they are specified and don't fail fast on the default signature call.