### PR TITLE
pygit: use anonymous remotes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,8 +22,6 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
         pyv: ['3.8', '3.9', '3.10', '3.11']
-        include:
-        - {os: ubuntu-latest, pyv: 'pypy3.8'}
 
     steps:
     - name: Check out the repository

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ nox.options.sessions = "lint", "tests"
 locations = "src", "tests"
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11", "pypy3.8", "pypy3.9"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 def tests(session: nox.Session) -> None:
     session.install(".[tests]")
     session.run(

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires=
     gitpython>3
     dulwich>=0.21.6
-    pygit2>=1.10.0
+    pygit2>=1.13.0
     pygtrie>=2.3.2
     fsspec>=2021.7.0
     pathspec>=0.9.0

--- a/src/scmrepo/git/backend/pygit2/__init__.py
+++ b/src/scmrepo/git/backend/pygit2/__init__.py
@@ -19,7 +19,6 @@ from typing import (
 from urllib.parse import urlparse
 
 from funcy import cached_property, reraise
-from shortuuid import uuid
 
 from scmrepo.exceptions import CloneError, MergeConflictError, RevError, SCMError
 from scmrepo.git.backend.base import BaseGitBackend, SyncStatus
@@ -567,11 +566,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         if os.name == "nt" and url.startswith("file://"):
             url = url[len("file://") :]
 
-        try:
-            remote_name = uuid()
-            yield self.repo.remotes.create(remote_name, url)
-        finally:
-            self.repo.remotes.delete(remote_name)
+        yield self.repo.remotes.create_anonymous(url)
 
     def fetch_refspecs(
         self,


### PR DESCRIPTION
Closes #258 

Also drops pypy testing in CI as pygit2 1.13.0 no longer builds wheels for pypy.