### PR TITLE
support LFS smudge (read operations)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ files = ["src", "tests"]
 [[tool.mypy.overrides]]
 module = [
     "pygtrie",
+    "dvc_http.*",
     "funcy",
     "git",
     "gitdb.*",

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires=
     gitpython>3
     dulwich>=0.21.6
-    pygit2>=1.13.0
+    pygit2>=1.13.3
     pygtrie>=2.3.2
     fsspec>=2021.7.0
     pathspec>=0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ install_requires=
     asyncssh>=2.13.1,<3
     funcy>=1.14
     shortuuid>=0.5.0
+    dvc-objects>=1.0.1,<2
+    dvc-http>=2.29.0
 
 [options.extras_require]
 tests =

--- a/src/scmrepo/base.py
+++ b/src/scmrepo/base.py
@@ -1,7 +1,8 @@
 """Manages source control systems (e.g. Git) in DVC."""
+from contextlib import AbstractContextManager
 
 
-class Base:
+class Base(AbstractContextManager):
     """Base class for source control management driver implementations."""
 
     def __init__(self, root_dir=None):
@@ -17,6 +18,9 @@ class Base:
         return "{class_name}: '{directory}'".format(
             class_name=type(self).__name__, directory=self.dir
         )
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
 
     @property
     def dir(self):

--- a/src/scmrepo/fs.py
+++ b/src/scmrepo/fs.py
@@ -187,9 +187,10 @@ class GitFileSystem(AbstractFileSystem):
         self,
         path: str,
         mode: str = "rb",
-        block_size: int = None,
+        block_size: Optional[int] = None,
         autocommit: bool = True,
-        cache_options: Dict = None,
+        cache_options: Optional[Dict] = None,
+        raw: bool = False,
         **kwargs: Any,
     ) -> BinaryIO:
         if mode != "rb":
@@ -197,7 +198,7 @@ class GitFileSystem(AbstractFileSystem):
 
         key = self._get_key(path)
         try:
-            obj = self.trie.open(key, mode=mode)
+            obj = self.trie.open(key, mode=mode, raw=raw)
             obj.size = bytesio_len(obj)
             return obj
         except KeyError as exc:

--- a/src/scmrepo/git/__init__.py
+++ b/src/scmrepo/git/__init__.py
@@ -171,6 +171,13 @@ class Git(Base):
     def ignore_file(self):
         return self.GITIGNORE
 
+    @cached_property
+    def lfs_storage(self):
+        from .lfs import LFSStorage
+
+        path = os.path.join(self._get_git_dir(self.root_dir), "lfs")
+        return LFSStorage(path)
+
     def _get_gitignore(self, path):
         ignore_file_dir = os.path.dirname(path)
 

--- a/src/scmrepo/git/__init__.py
+++ b/src/scmrepo/git/__init__.py
@@ -397,6 +397,7 @@ class Git(Base):
     check_ref_format = partialmethod(_backend_func, "check_ref_format")
     get_tag = partialmethod(_backend_func, "get_tag")
     get_config = partialmethod(_backend_func, "get_config")
+    check_attr = partialmethod(_backend_func, "check_attr")
 
     get_tree_obj = partialmethod(_backend_func, "get_tree_obj")
 

--- a/src/scmrepo/git/__init__.py
+++ b/src/scmrepo/git/__init__.py
@@ -358,6 +358,7 @@ class Git(Base):
     is_tracked = partialmethod(_backend_func, "is_tracked")
     is_dirty = partialmethod(_backend_func, "is_dirty")
     active_branch = partialmethod(_backend_func, "active_branch")
+    active_branch_remote = partialmethod(_backend_func, "active_branch_remote")
     list_branches = partialmethod(_backend_func, "list_branches")
     list_tags = partialmethod(_backend_func, "list_tags")
     list_all_commits = partialmethod(_backend_func, "list_all_commits")

--- a/src/scmrepo/git/__init__.py
+++ b/src/scmrepo/git/__init__.py
@@ -174,9 +174,9 @@ class Git(Base):
     @cached_property
     def lfs_storage(self):
         from .lfs import LFSStorage
+        from .lfs.storage import get_storage_path
 
-        path = os.path.join(self._get_git_dir(self.root_dir), "lfs")
-        return LFSStorage(path)
+        return LFSStorage(get_storage_path(self))
 
     def _get_gitignore(self, path):
         ignore_file_dir = os.path.dirname(path)

--- a/src/scmrepo/git/__init__.py
+++ b/src/scmrepo/git/__init__.py
@@ -274,6 +274,8 @@ class Git(Base):
 
     def close(self):
         self.backends.close_initialized()
+        if "lfs_storage" in self.__dict__:
+            self.lfs_storage.close()
 
     @property
     def no_commits(self):

--- a/src/scmrepo/git/backend/base.py
+++ b/src/scmrepo/git/backend/base.py
@@ -432,3 +432,24 @@ class BaseGitBackend(ABC):
                 returned. By default, the standard Git system/global/repo config
                 stack object will be returned.
         """
+
+    @abstractmethod
+    def check_attr(
+        self,
+        path: str,
+        attr: str,
+        source: Optional[str] = None,
+    ) -> Optional[Union[bool, str]]:
+        """Return the value of the specified attribute for a pathname.
+
+        Args:
+            path: Pathname to check.
+            attr: Attribute to check.
+            source: Optional tree-ish source to check.
+
+        Returns:
+            None when the attribute is not defined for the path (unspecified).
+            True when the attribute is defined as true (set).
+            False when the attribute is defined as false (unset).
+            The value of the attribute when a value has been assigned.
+        """

--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -51,7 +51,16 @@ class DulwichObject(GitObject):
         self._mode = mode
         self._sha = sha
 
-    def open(self, mode: str = "r", encoding: str = None):
+    def open(
+        self,
+        mode: str = "r",
+        encoding: Optional[str] = None,
+        raw: bool = True,
+        rev: Optional[str] = None,
+        **kwargs,
+    ):
+        if not raw:
+            raise NotImplementedError
         if not encoding:
             encoding = locale.getpreferredencoding(False)
         # NOTE: we didn't load the object before as Dulwich will also try to

--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -971,6 +971,14 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             return DulwichConfig(ConfigFile.from_path(path))
         return DulwichConfig(self.repo.get_config_stack())
 
+    def check_attr(
+        self,
+        path: str,
+        attr: str,
+        source: Optional[str] = None,
+    ) -> Optional[Union[bool, str]]:
+        raise NotImplementedError
+
 
 _IDENTITY_RE = re.compile(r"(?P<name>.+)\s+<(?P<email>.+)>")
 

--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -51,7 +51,7 @@ class DulwichObject(GitObject):
         self._mode = mode
         self._sha = sha
 
-    def open(
+    def open(  # pylint: disable=unused-argument
         self,
         mode: str = "r",
         encoding: Optional[str] = None,
@@ -153,18 +153,18 @@ class DulwichConfig(Config):
             return self._config.encoding
         return self._config.backends[0].encoding
 
-    def get(self, section: Tuple[str], name: str) -> str:
+    def get(self, section: Tuple[str, ...], name: str) -> str:
         """Return the specified setting as a string."""
         return self._config.get(section, name).decode(self.encoding)
 
-    def get_bool(self, section: Tuple[str], name: str) -> bool:
+    def get_bool(self, section: Tuple[str, ...], name: str) -> bool:
         """Return the specified setting as a boolean."""
         value = self._config.get_boolean(section, name)
         if value is None:
             raise ValueError("setting is not a valid boolean")
         return value
 
-    def get_multivar(self, section: Tuple[str], name: str) -> Iterator[str]:
+    def get_multivar(self, section: Tuple[str, ...], name: str) -> Iterator[str]:
         """Iterate over string values in the specified multivar setting."""
         for value in self._config.get_multivar(section, name):
             yield value.decode(self.encoding)

--- a/src/scmrepo/git/backend/gitpython.py
+++ b/src/scmrepo/git/backend/gitpython.py
@@ -83,7 +83,15 @@ class GitPythonObject(GitObject):
     def __init__(self, obj):
         self.obj = obj
 
-    def open(self, mode: str = "r", encoding: str = None):
+    def open(
+        self,
+        mode: str = "r",
+        encoding: str = None,
+        raw: bool = True,
+        **kwargs,
+    ):
+        if not raw:
+            raise NotImplementedError
         if not encoding:
             encoding = locale.getpreferredencoding(False)
         # GitPython's obj.data_stream is a fragile thing, it is better to

--- a/src/scmrepo/git/backend/pygit2/filter.py
+++ b/src/scmrepo/git/backend/pygit2/filter.py
@@ -43,14 +43,17 @@ class LFSFilter(Filter):
             self._smudge(self._smudge_src, write_next)
 
     def _smudge(self, src: "FilterSource", write_next: Callable[[bytes], None]):
+        from scmpreo.exceptions import InvalidRemote
+
         from scmrepo.git import Git
         from scmrepo.git.lfs import smudge
+        from scmrepo.git.lfs.fetch import get_fetch_url
 
         self._smudge_buf.seek(0)
         with Git(src.repo.workdir) as scm:
             try:
-                url: Optional[str] = src.repo.remotes["origin"].url
-            except KeyError:
+                url = get_fetch_url(scm)
+            except InvalidRemote:
                 url = None
             fobj = smudge(scm.lfs_storage, self._smudge_buf, url=url)
             data = fobj.read(io.DEFAULT_BUFFER_SIZE)

--- a/src/scmrepo/git/backend/pygit2/filter.py
+++ b/src/scmrepo/git/backend/pygit2/filter.py
@@ -1,0 +1,53 @@
+import io
+import logging
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+from pygit2 import GIT_FILTER_CLEAN, Filter, Passthrough
+
+if TYPE_CHECKING:
+    from pygit2 import FilterSource
+
+logger = logging.getLogger(__name__)
+
+
+class LFSFilter(Filter):
+    attributes = "filter=*"
+
+    def __init__(self, *args, **kwargs):
+        self._smudge_buf: Optional[io.BytesIO] = None
+
+    def check(self, src: "FilterSource", attr_values: List[str]):
+        if attr_values[0] == "lfs":
+            if src.mode != GIT_FILTER_CLEAN:
+                self._smudge_buf = io.BytesIO()
+                return
+        raise Passthrough
+
+    def write(
+        self, data: bytes, src: "FilterSource", write_next: Callable[[bytes], None]
+    ):
+        if src.mode == GIT_FILTER_CLEAN:
+            write_next(data)
+            return
+        if self._smudge_buf is None:
+            self._smudge_buf = io.BytesIO()
+        self._smudge_buf.write(data)
+
+    def close(self, write_next: Callable[[bytes], None]):
+        if self._smudge_buf is not None:
+            self._smudge(write_next)
+
+    def _smudge(self, write_next: Callable[[bytes], None]):
+        from scmrepo.git import Git
+        from scmrepo.git.lfs import smudge
+
+        self._smudge_buf.seek(0)
+        scm = Git()
+        try:
+            with smudge(scm.lfs_storage, self._smudge_buf) as fobj:
+                data = fobj.read(io.DEFAULT_BUFFER_SIZE)
+                while data:
+                    write_next(data)
+                    data = fobj.read(io.DEFAULT_BUFFER_SIZE)
+        finally:
+            scm.close()

--- a/src/scmrepo/git/backend/pygit2/filter.py
+++ b/src/scmrepo/git/backend/pygit2/filter.py
@@ -15,7 +15,7 @@ class LFSFilter(Filter):
 
     def __init__(self, *args, **kwargs):
         self._smudge_buf: Optional[io.BytesIO] = None
-        self._smudge_git_dir: Optional[str] = None
+        self._smudge_root: Optional[str] = None
 
     def check(self, src: "FilterSource", attr_values: List[str]):
         if attr_values[0] == "lfs":
@@ -48,6 +48,7 @@ class LFSFilter(Filter):
         from scmrepo.git.lfs import smudge
         from scmrepo.git.lfs.fetch import get_fetch_url
 
+        assert self._smudge_buf is not None
         self._smudge_buf.seek(0)
         with Git(self._smudge_root) as scm:
             try:

--- a/src/scmrepo/git/config.py
+++ b/src/scmrepo/git/config.py
@@ -10,7 +10,7 @@ class Config(ABC):
     """Read-only Git config."""
 
     @abstractmethod
-    def get(self, section: Tuple[str], name: str) -> str:
+    def get(self, section: Tuple[str, ...], name: str) -> str:
         """Return the specified setting as a string.
 
         Raises:
@@ -18,7 +18,7 @@ class Config(ABC):
         """
 
     @abstractmethod
-    def get_bool(self, section: Tuple[str], name: str) -> bool:
+    def get_bool(self, section: Tuple[str, ...], name: str) -> bool:
         """Return the specified setting as a boolean.
 
         Raises:
@@ -27,7 +27,7 @@ class Config(ABC):
         """
 
     @abstractmethod
-    def get_multivar(self, section: Tuple[str], name: str) -> Iterator[str]:
+    def get_multivar(self, section: Tuple[str, ...], name: str) -> Iterator[str]:
         """Iterate over string values in the specified multivar setting.
 
         Raises:

--- a/src/scmrepo/git/lfs/__init__.py
+++ b/src/scmrepo/git/lfs/__init__.py
@@ -1,7 +1,8 @@
 from .client import LFSClient
 from .exceptions import LFSError
+from .fetch import fetch
 from .pointer import Pointer
 from .smudge import smudge
 from .storage import LFSStorage
 
-__all__ = ["LFSClient", "LFSError", "LFSStorage", "Pointer", "smudge"]
+__all__ = ["LFSClient", "LFSError", "LFSStorage", "Pointer", "fetch", "smudge"]

--- a/src/scmrepo/git/lfs/__init__.py
+++ b/src/scmrepo/git/lfs/__init__.py
@@ -1,4 +1,7 @@
+from .client import LFSClient
+from .exceptions import LFSError
+from .pointer import Pointer
 from .smudge import smudge
 from .storage import LFSStorage
 
-__all__ = ["LFSStorage", "smudge"]
+__all__ = ["LFSClient", "LFSError", "LFSStorage", "Pointer", "smudge"]

--- a/src/scmrepo/git/lfs/__init__.py
+++ b/src/scmrepo/git/lfs/__init__.py
@@ -1,0 +1,4 @@
+from .smudge import smudge
+from .storage import LFSStorage
+
+__all__ = ["LFSStorage", "smudge"]

--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -78,7 +78,7 @@ def _authed(f: Coroutine):
     async def wrapper(self, *args, **kwargs):
         try:
             return await f(self, *args, **kwargs)
-        except aiohttp.ClientReponseError as exc:
+        except aiohttp.ClientResponseError as exc:
             if exc.status != 401:
                 raise
             session = await self._set_session()

--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -191,7 +191,6 @@ class LFSClient(AbstractContextManager):
             get_coro = callback.wrap_and_branch_coro(
                 self.httpfs._get_file  # pylint: disable=protected-access
             )
-            # get_coro = self.httpfs._get_file  # pylint: disable=protected-access
             with as_atomic(localfs, to_path, create_parents=True) as tmp_file:
                 return await get_coro(
                     from_path,

--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -1,0 +1,222 @@
+import logging
+from contextlib import AbstractContextManager
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Coroutine, Dict, Iterable, Optional
+
+import aiohttp
+from dvc_http import HTTPFileSystem
+from dvc_http.retry import ReadOnlyRetryClient
+from dvc_objects.executors import batch_coros
+from dvc_objects.fs import localfs
+from dvc_objects.fs.callbacks import DEFAULT_CALLBACK
+from dvc_objects.fs.utils import as_atomic
+from fsspec.asyn import sync_wrapper
+from funcy import cached_property
+
+from ..credentials import Credential, CredentialNotFoundError
+from .exceptions import LFSError
+from .pointer import Pointer
+
+if TYPE_CHECKING:
+    from dvc_objects.fs.callbacks import Callback
+
+    from .storage import LFSStorage
+
+logger = logging.getLogger(__name__)
+
+
+class _LFSClient(ReadOnlyRetryClient):
+    async def _request(self, *args, **kwargs):
+        return await super()._request(*args, **kwargs)
+
+
+class _LFSFileSystem(HTTPFileSystem):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _prepare_credentials(self, **config):
+        return {}
+
+    async def get_client(self, **kwargs):
+        from aiohttp_retry import ExponentialRetry
+        from dvc_http import make_context
+
+        kwargs["retry_options"] = ExponentialRetry(
+            attempts=self.SESSION_RETRIES,
+            factor=self.SESSION_BACKOFF_FACTOR,
+            max_timeout=self.REQUEST_TIMEOUT,
+            exceptions={aiohttp.ClientError},
+        )
+
+        # The default total timeout for an aiohttp request is 300 seconds
+        # which is too low for DVC's interactions when dealing with large
+        # data blobs. We remove the total timeout, and only limit the time
+        # that is spent when connecting to the remote server and waiting
+        # for new data portions.
+        connect_timeout = kwargs.pop("connect_timeout")
+        kwargs["timeout"] = aiohttp.ClientTimeout(
+            total=None,
+            connect=connect_timeout,
+            sock_connect=connect_timeout,
+            sock_read=kwargs.pop("read_timeout"),
+        )
+
+        kwargs["connector"] = aiohttp.TCPConnector(
+            # Force cleanup of closed SSL transports.
+            # See https://github.com/iterative/dvc/issues/7414
+            enable_cleanup_closed=True,
+            ssl=make_context(kwargs.pop("ssl_verify", None)),
+        )
+
+        return ReadOnlyRetryClient(**kwargs)
+
+
+def _authed(f: Coroutine):
+    """Set credentials and retry the given coroutine if needed."""
+
+    @wraps(f)
+    async def wrapper(self, *args, **kwargs):
+        try:
+            return await f(self, *args, **kwargs)
+        except aiohttp.ClientReponseError as exc:
+            if exc.status != 401:
+                raise
+            session = await self._set_session()
+            if session.auth:
+                raise
+            auth = self._get_auth()
+            if auth is None:
+                raise
+            self._session._auth = auth
+        return await f(self, *args, **kwargs)
+
+    return wrapper
+
+
+class LFSClient(AbstractContextManager):
+    """Naive read-only LFS HTTP client."""
+
+    JSON_CONTENT_TYPE = "application/vnd.git-lfs+json"
+
+    def __init__(
+        self,
+        url: str,
+        git_url: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ):
+        """
+        Args:
+            url: LFS server URL.
+        """
+        self.url = url
+        self.git_url = git_url
+        self.headers = {}
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+    @cached_property
+    def fs(self) -> "_LFSFileSystem":
+        return _LFSFileSystem()
+
+    @property
+    def httpfs(self) -> "HTTPFileSystem":
+        return self.fs.fs
+
+    @property
+    def loop(self):
+        return self.httpfs.loop
+
+    @classmethod
+    def from_git_url(cls, git_url: str) -> "LFSClient":
+        if git_url.endswith(".git"):
+            url = f"{git_url}/info/lfs"
+        else:
+            url = f"{git_url}.git/info/lfs"
+        return cls(url, git_url=git_url)
+
+    def close(self):
+        pass
+
+    def _get_auth(self) -> Optional[aiohttp.BasicAuth]:
+        try:
+            creds = Credential(url=self.git_url).fill()
+            if creds.username and creds.password:
+                return aiohttp.BasicAuth(creds.username, creds.password)
+        except CredentialNotFoundError:
+            pass
+        return None
+
+    async def _set_session(self) -> aiohttp.ClientSession:
+        return await self.fs.fs.set_session()
+
+    @_authed
+    async def _batch_request(
+        self,
+        objects: Iterable[Pointer],
+        upload: bool = False,
+        ref: Optional[str] = None,
+        hash_algo: str = "sha256",
+    ) -> Dict[str, Any]:
+        """Send LFS API /objects/batch request."""
+        url = f"{self.url}/objects/batch"
+        body: Dict[str, Any] = {
+            "operation": "upload" if upload else "download",
+            "transfers": ["basic"],
+            "objects": [{"oid": obj.oid, "size": obj.size} for obj in objects],
+            "hash_algo": hash_algo,
+        }
+        if ref:
+            body["ref"] = [{"name": ref}]
+        session = await self._set_session()
+        headers = dict(self.headers)
+        headers["Content-Type"] = self.JSON_CONTENT_TYPE
+        async with session.post(
+            url,
+            headers=headers,
+            json=body,
+        ) as resp:
+            data = await resp.json()
+        return data
+
+    @_authed
+    async def _download(
+        self,
+        storage: "LFSStorage",
+        objects: Iterable[Pointer],
+        callback: "Callback" = DEFAULT_CALLBACK,
+        **kwargs,
+    ):
+        async def _get_one(from_path: str, to_path: str, **kwargs):
+            get_coro = callback.wrap_and_branch_coro(
+                self.httpfs._get_file  # pylint: disable=protected-access
+            )
+            # get_coro = self.httpfs._get_file  # pylint: disable=protected-access
+            with as_atomic(localfs, to_path, create_parents=True) as tmp_file:
+                return await get_coro(
+                    from_path,
+                    tmp_file,
+                    **kwargs,
+                )
+
+        resp_data = await self._batch_request(objects, **kwargs)
+        if resp_data.get("transfer") != "basic":
+            raise LFSError("Unsupported LFS transfer type")
+        coros = []
+        for data in resp_data.get("objects", []):
+            obj = Pointer(data["oid"], data["size"])
+            download = data.get("actions", {}).get("download", {})
+            url = download.get("href")
+            if not url:
+                logger.debug("No download URL for LFS object '%s'", obj)
+                continue
+            headers = download.get("header", {})
+            to_path = storage.oid_to_path(obj.oid)
+            coros.append(_get_one(url, to_path, headers=headers))
+        for result in await batch_coros(
+            coros, batch_size=self.fs.jobs, return_exceptions=True
+        ):
+            if isinstance(result, BaseException):
+                raise result
+
+    download = sync_wrapper(_download)

--- a/src/scmrepo/git/lfs/exceptions.py
+++ b/src/scmrepo/git/lfs/exceptions.py
@@ -1,0 +1,5 @@
+from scmrepo.exceptions import SCMError
+
+
+class LFSError(SCMError):
+    pass

--- a/src/scmrepo/git/lfs/fetch.py
+++ b/src/scmrepo/git/lfs/fetch.py
@@ -1,0 +1,102 @@
+import fnmatch
+import io
+from typing import TYPE_CHECKING, Iterable, Iterator, List, Optional
+
+from scmrepo.exceptions import InvalidRemote
+
+from .pointer import HEADERS, Pointer
+
+if TYPE_CHECKING:
+    from scmrepo.git import Git
+
+
+def fetch(
+    scm: "Git",
+    revs: Optional[List[str]] = None,
+    remote: Optional[str] = None,
+    include: Optional[List[str]] = None,
+    exclude: Optional[List[str]] = None,
+):
+    # NOTE: This currently does not support fetching objects from the worktree
+    if not revs:
+        revs = ["HEAD"]
+    if not remote:
+        remote = "origin"
+    objects = set()
+    for rev in revs:
+        objects.update(
+            pointer
+            for pointer in _collect_objects(scm, rev, include, exclude)
+            if not scm.lfs_storage.exists(pointer)
+        )
+    try:
+        url = scm.get_remote_url(remote)
+    except InvalidRemote:
+        # treat remote as a raw git URL
+        url = remote
+    scm.lfs_storage.fetch(url, objects)
+
+
+def _collect_objects(
+    scm: "Git",
+    rev: str,
+    include: Optional[List[str]],
+    exclude: Optional[List[str]],
+) -> Iterator[Pointer]:
+    fs = scm.get_fs(rev)
+    for path in _filter_paths(fs.find("/"), include, exclude):
+        check_path = path.lstrip("/")
+        if scm.check_attr(check_path, "filter", source=rev) == "lfs":
+            try:
+                with fs.open(path, "rb", raw=True) as fobj:
+                    with io.BufferedReader(fobj) as reader:
+                        data = reader.peek(100)
+                        if any(data.startswith(header) for header in HEADERS):
+                            yield Pointer.load(reader)
+            except (ValueError, OSError):
+                pass
+
+
+def _filter_paths(
+    paths: Iterable[str], include: Optional[List[str]], exclude: Optional[List[str]]
+) -> Iterator[str]:
+    filtered = set()
+    if include:
+        for pattern in include:
+            filtered.update(fnmatch.filter(paths, pattern))
+    else:
+        filtered.update(paths)
+    if exclude:
+        for pattern in exclude:
+            filtered.difference_update(fnmatch.filter(paths, pattern))
+    yield from filtered
+
+
+if __name__ == "__main__":
+    # Minimal `git lfs fetch` CLI implementation
+    import argparse
+    import sys
+
+    from scmrepo.git import Git  # noqa: F811
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download Git LFS objects at the given refs from the specified remote."
+        ),
+    )
+    parser.add_argument(
+        "remote",
+        nargs="?",
+        default="origin",
+        help="Remote to fetch from. Defaults to 'origin'.",
+    )
+    parser.add_argument(
+        "refs",
+        nargs="*",
+        default=["HEAD"],
+        help="Refs or commits to fetch. Defaults to 'HEAD'.",
+    )
+    args = parser.parse_args()
+    with Git(".") as scm:
+        print("fetch: fetching reference", ", ".join(args.refs), file=sys.stderr)
+        fetch(scm, revs=args.refs, remote=args.remote)

--- a/src/scmrepo/git/lfs/fetch.py
+++ b/src/scmrepo/git/lfs/fetch.py
@@ -1,7 +1,7 @@
 import fnmatch
 import io
 import os
-from typing import TYPE_CHECKING, Iterable, Iterator, List, Optional
+from typing import TYPE_CHECKING, Callable, Iterable, Iterator, List, Optional
 
 from scmrepo.exceptions import InvalidRemote, SCMError
 
@@ -10,6 +10,7 @@ from .pointer import HEADERS, Pointer
 if TYPE_CHECKING:
     from scmrepo.git import Git
     from scmrepo.git.config import Config
+    from scmrepo.progress import GitProgressEvent
 
 
 def fetch(
@@ -18,6 +19,7 @@ def fetch(
     remote: Optional[str] = None,
     include: Optional[List[str]] = None,
     exclude: Optional[List[str]] = None,
+    progress: Optional[Callable[["GitProgressEvent"], None]] = None,
 ):
     # NOTE: This currently does not support fetching objects from the worktree
     if not revs:
@@ -39,7 +41,7 @@ def fetch(
             url = remote
         else:
             raise
-    scm.lfs_storage.fetch(url, objects)
+    scm.lfs_storage.fetch(url, objects, progress=progress)
 
 
 def get_fetch_url(scm: "Git", remote: Optional[str] = None):  # noqa: C901

--- a/src/scmrepo/git/lfs/fetch.py
+++ b/src/scmrepo/git/lfs/fetch.py
@@ -1,7 +1,7 @@
 import fnmatch
 import io
 import os
-from typing import TYPE_CHECKING, Callable, Iterable, Iterator, List, Optional
+from typing import TYPE_CHECKING, Callable, Iterable, Iterator, List, Optional, Set
 
 from scmrepo.exceptions import InvalidRemote, SCMError
 
@@ -24,7 +24,7 @@ def fetch(
     # NOTE: This currently does not support fetching objects from the worktree
     if not revs:
         revs = ["HEAD"]
-    objects = set()
+    objects: Set[Pointer] = set()
     for rev in revs:
         objects.update(
             pointer
@@ -82,6 +82,7 @@ def get_fetch_url(scm: "Git", remote: Optional[str] = None):  # noqa: C901
             remote = "origin"
 
     # check remote.*.lfsurl (can be set in git config and .lfsconfig)
+    assert remote is not None
     try:
         return git_config.get(("remote", remote), "lfsurl")
     except KeyError:
@@ -156,6 +157,6 @@ if __name__ == "__main__":
         help="Refs or commits to fetch. Defaults to 'HEAD'.",
     )
     args = parser.parse_args()
-    with Git(".") as scm:
+    with Git(".") as scm_:  # pylint: disable=E0601
         print("fetch: fetching reference", ", ".join(args.refs), file=sys.stderr)
-        fetch(scm, revs=args.refs, remote=args.remote)
+        fetch(scm_, revs=args.refs, remote=args.remote)

--- a/src/scmrepo/git/lfs/object.py
+++ b/src/scmrepo/git/lfs/object.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, fields
+from typing import Any, Dict
+
+
+@dataclass(frozen=True)
+class LFSObject:
+    oid: str
+    size: int
+
+    def __str__(self) -> str:
+        return self.oid
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "LFSObject":
+        return cls(**{k: v for k, v in d.items() if k in fields(cls)})

--- a/src/scmrepo/git/lfs/pointer.py
+++ b/src/scmrepo/git/lfs/pointer.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 LFS_VERSION = "https://git-lfs.github.com/spec/v1"
 LEGACY_LFS_VERSION = "https://hawser.github.com/spec/v1"
 ALLOWED_VERSIONS = (LFS_VERSION, LEGACY_LFS_VERSION)
+HEADERS = [(b"version " + version.encode("utf-8")) for version in ALLOWED_VERSIONS]
 
 
 def _get_kv(line: str) -> Tuple[str, str]:
@@ -25,6 +26,9 @@ class Pointer:
         self.oid = oid
         self.size = size
         self._dict = kwargs
+
+    def __hash__(self):
+        return hash(self.dump())
 
     @classmethod
     def build(cls, fobj: BinaryIO) -> "Pointer":

--- a/src/scmrepo/git/lfs/pointer.py
+++ b/src/scmrepo/git/lfs/pointer.py
@@ -1,0 +1,103 @@
+import hashlib
+import io
+import logging
+from dataclasses import dataclass
+from typing import IO, BinaryIO, TextIO, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+LFS_VERSION = "https://git-lfs.github.com/spec/v1"
+LEGACY_LFS_VERSION = "https://hawser.github.com/spec/v1"
+ALLOWED_VERSIONS = (LFS_VERSION, LEGACY_LFS_VERSION)
+
+
+def _get_kv(line: str) -> Tuple[str, str]:
+    return line.strip().split(maxsplit=1)
+
+
+@dataclass
+class Pointer:
+    oid: str
+    size: int
+
+    def __init__(self, oid: str, size: int, **kwargs):
+        self.oid = oid
+        self.size = size
+        self._dict = kwargs
+
+    @classmethod
+    def build(cls, fobj: BinaryIO) -> "Pointer":
+        m = hashlib.sha256()
+        data = fobj.read()
+        m.update(data)
+        return cls(m.hexdigest(), len(data))
+
+    @classmethod
+    def load(cls, fobj: IO) -> "Pointer":
+        """Load the specified pointer file."""
+
+        if isinstance(fobj, io.TextIOBase):
+            text_obj: TextIO = fobj
+        else:
+            text_obj = io.TextIOWrapper(fobj, encoding="utf-8")
+
+        cls.check_version(text_obj.readline())
+        d = dict(_get_kv(line) for line in text_obj.readlines())
+        try:
+            value = d.pop("oid")
+            hash_method, oid = value.split(":", maxsplit=1)
+            if hash_method != "sha256":
+                raise ValueError("Invalid LFS hash method '{hash_method}'")
+        except ValueError as e:
+            raise ValueError("Invalid LFS pointer oid") from e
+        try:
+            value = d.pop("size")
+            size = int(value)
+        except ValueError as e:
+            raise ValueError("Invalid LFS pointer size") from e
+
+        return cls(oid, size, **d)
+
+    @staticmethod
+    def check_version(line: str):
+        try:
+            key, value = _get_kv(line)
+            if key != "version":
+                raise ValueError("LFS pointer file must start with 'version'")
+            if value not in ALLOWED_VERSIONS:
+                raise ValueError(f"Unsupported LFS pointer version '{value}'")
+        except (ValueError, OSError) as e:
+            raise ValueError("Invalid LFS pointer file") from e
+
+    def dump(self) -> str:
+        d = {
+            "oid": f"sha256:{self.oid}",
+            "size": self.size,
+        }
+        d.update(self._dict)
+        return "\n".join(
+            [f"version {LFS_VERSION}"] + [f"{key} {d[key]}" for key in sorted(d)] + [""]
+        )
+
+    def to_bytes(self) -> bytes:
+        return self.dump().encode("utf-8")
+
+
+if __name__ == "__main__":
+    # Minimal `git lfs pointer` CLI implementation
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Build generated pointer files.",
+    )
+    parser.add_argument("--file", help="A local file to build the pointer from.")
+    args = parser.parse_args()
+    if not args.file:
+        sys.exit("Nothing to do")
+
+    print(f"Git LFS pointer for {args.file}\n", file=sys.stderr)
+    with open(args.file, mode="rb") as fobj:
+        p = Pointer.build(fobj)
+    print(p.dump(), end="")

--- a/src/scmrepo/git/lfs/pointer.py
+++ b/src/scmrepo/git/lfs/pointer.py
@@ -14,7 +14,8 @@ HEADERS = [(b"version " + version.encode("utf-8")) for version in ALLOWED_VERSIO
 
 
 def _get_kv(line: str) -> Tuple[str, str]:
-    return line.strip().split(maxsplit=1)
+    key, value = line.strip().split(maxsplit=1)
+    return key, value
 
 
 @dataclass
@@ -41,8 +42,9 @@ class Pointer:
     def load(cls, fobj: IO) -> "Pointer":
         """Load the specified pointer file."""
 
-        if isinstance(fobj, io.TextIOBase):
-            text_obj: TextIO = fobj
+        if isinstance(fobj, io.TextIOBase):  # type: ignore[unreachable]
+            text_obj: TextIO = fobj  # type: ignore[unreachable]
+
         else:
             text_obj = io.TextIOWrapper(fobj, encoding="utf-8")
 
@@ -102,6 +104,6 @@ if __name__ == "__main__":
         sys.exit("Nothing to do")
 
     print(f"Git LFS pointer for {args.file}\n", file=sys.stderr)
-    with open(args.file, mode="rb") as fobj:
-        p = Pointer.build(fobj)
+    with open(args.file, mode="rb") as fobj_:
+        p = Pointer.build(fobj_)
     print(p.dump(), end="")

--- a/src/scmrepo/git/lfs/progress.py
+++ b/src/scmrepo/git/lfs/progress.py
@@ -35,13 +35,13 @@ class LFSCallback(Callback):
 
     def branch(
         self,
-        path_1: "Union[str, BinaryIO]",
+        path_1: Union[str, BinaryIO],
         path_2: str,
         kwargs: Dict[str, Any],
         child: Optional[Callback] = None,
     ):
         if child:
-            child = child
+            pass
         elif self.git_progress:
             child = TqdmCallback(
                 bytes=True, desc=path_1 if isinstance(path_1, str) else path_2

--- a/src/scmrepo/git/lfs/progress.py
+++ b/src/scmrepo/git/lfs/progress.py
@@ -1,0 +1,61 @@
+from typing import Any, BinaryIO, Callable, Dict, Optional, Union
+
+from dvc_objects.fs.callbacks import DEFAULT_CALLBACK, Callback, TqdmCallback
+
+from scmrepo.progress import GitProgressEvent
+
+
+class LFSCallback(Callback):
+    """Callback subclass to generate Git/LFS style progress."""
+
+    def __init__(
+        self,
+        *args,
+        git_progress: Optional[Callable[[GitProgressEvent], None]] = None,
+        direction: str = "Downloading",
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.direction = direction
+        self.git_progress = git_progress
+
+    def call(self, *args, **kwargs):
+        super().call(*args, **kwargs)
+        self._update_git()
+
+    def _update_git(self):
+        if not self.git_progress:
+            return
+        event = GitProgressEvent(
+            phase=f"{self.direction} LFS objects",
+            completed=self.value,
+            total=self.size,
+        )
+        self.git_progress(event)
+
+    def branch(
+        self,
+        path_1: "Union[str, BinaryIO]",
+        path_2: str,
+        kwargs: Dict[str, Any],
+        child: Optional[Callback] = None,
+    ):
+        if child:
+            child = child
+        elif self.git_progress:
+            child = TqdmCallback(
+                bytes=True, desc=path_1 if isinstance(path_1, str) else path_2
+            )
+        else:
+            child = DEFAULT_CALLBACK
+        return super().branch(path_1, path_2, kwargs, child=child)
+
+    @classmethod
+    def as_lfs_callback(
+        cls,
+        git_progress: Optional[Callable[[GitProgressEvent], None]] = None,
+        **kwargs,
+    ):
+        if git_progress is None:
+            return DEFAULT_CALLBACK
+        return cls(git_progress=git_progress, **kwargs)

--- a/src/scmrepo/git/lfs/smudge.py
+++ b/src/scmrepo/git/lfs/smudge.py
@@ -1,0 +1,52 @@
+import io
+import logging
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, BinaryIO, Optional
+
+from .pointer import ALLOWED_VERSIONS, Pointer
+
+if TYPE_CHECKING:
+    from .storage import LFSStorage
+
+logger = logging.getLogger(__name__)
+
+
+_HEADERS = (b"version " + version.encode("utf-8") for version in ALLOWED_VERSIONS)
+
+
+@contextmanager
+def smudge(storage: "LFSStorage", fobj: BinaryIO) -> BinaryIO:
+    """Wrap the specified binary IO stream and run LFS smudge if necessary."""
+    reader = io.BufferedReader(fobj)
+    data = reader.peek(100)
+    if any(data.startswith(header) for header in _HEADERS):
+        lfs_obj: Optional[BinaryIO] = None
+        try:
+            pointer = Pointer.load(reader)
+            lfs_obj = storage.open(pointer.oid, mode="rb")
+        except (ValueError, OSError):
+            logger.warning("Could not open LFS object, falling back to pointer")
+        if lfs_obj:
+            with lfs_obj:
+                yield lfs_obj
+            return
+    yield reader
+
+
+if __name__ == "__main__":
+    # Minimal `git lfs smudge` CLI implementation
+    import sys
+
+    from scmrepo.git import Git
+
+    if sys.stdin.isatty():
+        sys.exit(
+            "Cannot read from STDIN: "
+            "This command should be run by the Git 'smudge' filter"
+        )
+    scm = Git()
+    try:
+        with smudge(scm.lfs_storage, sys.stdin.buffer) as fobj:
+            sys.stdout.buffer.write(fobj.read())
+    finally:
+        scm.close()

--- a/src/scmrepo/git/lfs/smudge.py
+++ b/src/scmrepo/git/lfs/smudge.py
@@ -2,15 +2,12 @@ import io
 import logging
 from typing import TYPE_CHECKING, BinaryIO, Optional
 
-from .pointer import ALLOWED_VERSIONS, Pointer
+from .pointer import HEADERS, Pointer
 
 if TYPE_CHECKING:
     from .storage import LFSStorage
 
 logger = logging.getLogger(__name__)
-
-
-_HEADERS = (b"version " + version.encode("utf-8") for version in ALLOWED_VERSIONS)
 
 
 def smudge(
@@ -19,7 +16,7 @@ def smudge(
     """Wrap the specified binary IO stream and run LFS smudge if necessary."""
     reader = io.BufferedReader(fobj)
     data = reader.peek(100)
-    if any(data.startswith(header) for header in _HEADERS):
+    if any(data.startswith(header) for header in HEADERS):
         # read the pointer data into memory since the raw stream is unseekable
         # and we may need to return it in fallback case
         data = reader.read()

--- a/src/scmrepo/git/lfs/smudge.py
+++ b/src/scmrepo/git/lfs/smudge.py
@@ -14,7 +14,7 @@ def smudge(
     storage: "LFSStorage", fobj: BinaryIO, url: Optional[str] = None
 ) -> BinaryIO:
     """Wrap the specified binary IO stream and run LFS smudge if necessary."""
-    reader = io.BufferedReader(fobj)
+    reader = io.BufferedReader(fobj)  # type: ignore[arg-type]
     data = reader.peek(100)
     if any(data.startswith(header) for header in HEADERS):
         # read the pointer data into memory since the raw stream is unseekable
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         )
     scm = Git()
     try:
-        with smudge(scm.lfs_storage, sys.stdin.buffer) as fobj:
-            sys.stdout.buffer.write(fobj.read())
+        with smudge(scm.lfs_storage, sys.stdin.buffer) as fobj_:
+            sys.stdout.buffer.write(fobj_.read())
     finally:
         scm.close()

--- a/src/scmrepo/git/lfs/storage.py
+++ b/src/scmrepo/git/lfs/storage.py
@@ -1,0 +1,13 @@
+import os
+from typing import BinaryIO
+
+
+class LFSStorage:
+    def __init__(self, path: str):
+        self.path = path
+
+    def oid_to_path(self, oid: str):
+        return os.path.join(self.path, "objects", oid[0:2], oid[2:4], oid)
+
+    def open(self, oid: str, **kwargs) -> BinaryIO:
+        return open(self.oid_to_path(oid), **kwargs)

--- a/src/scmrepo/git/lfs/storage.py
+++ b/src/scmrepo/git/lfs/storage.py
@@ -1,10 +1,13 @@
 import errno
 import os
-from typing import BinaryIO, Collection, Optional, Union
+from typing import TYPE_CHECKING, BinaryIO, Collection, Optional, Union
 
 from dvc_objects.fs.callbacks import TqdmCallback
 
 from .pointer import Pointer
+
+if TYPE_CHECKING:
+    from scmrepo.git import Git
 
 
 class LFSStorage:
@@ -50,3 +53,17 @@ class LFSStorage:
 
     def close(self):
         pass
+
+
+def get_storage_path(scm: "Git") -> str:
+    """Return the LFS storage directory for the specified repository."""
+
+    config = scm.get_config()
+    git_dir = scm._get_git_dir(scm.root_dir)  # pylint: disable=protected-access
+    try:
+        path = config.get(("lfs",), "storage")
+        if os.path.isabs(path):
+            return path
+    except KeyError:
+        path = "lfs"
+    return os.path.join(git_dir, path)

--- a/src/scmrepo/git/lfs/storage.py
+++ b/src/scmrepo/git/lfs/storage.py
@@ -44,7 +44,7 @@ class LFSStorage:
         oid = obj if isinstance(obj, str) else obj.oid
         path = self.oid_to_path(oid)
         try:
-            return open(path, **kwargs)
+            return open(path, **kwargs)  # pylint: disable=unspecified-encoding
         except FileNotFoundError:
             if not fetch_url or not isinstance(obj, Pointer):
                 raise
@@ -54,7 +54,7 @@ class LFSStorage:
             raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), path
             ) from exc
-        return open(path, **kwargs)
+        return open(path, **kwargs)  # pylint: disable=unspecified-encoding
 
     def close(self):
         pass

--- a/src/scmrepo/git/lfs/storage.py
+++ b/src/scmrepo/git/lfs/storage.py
@@ -1,13 +1,48 @@
+import errno
 import os
-from typing import BinaryIO
+from typing import BinaryIO, Collection, Optional, Union
+
+from dvc_objects.fs.callbacks import TqdmCallback
+
+from .pointer import Pointer
 
 
 class LFSStorage:
     def __init__(self, path: str):
         self.path = path
 
+    def fetch(self, url: str, objects: Collection[Pointer]):
+        from .client import LFSClient
+
+        with TqdmCallback(desc="Fetching LFS objects", unit="obj") as cb:
+            cb.set_size(len(objects))
+            with LFSClient.from_git_url(url) as client:
+                client.download(self, objects, callback=cb)
+
     def oid_to_path(self, oid: str):
         return os.path.join(self.path, "objects", oid[0:2], oid[2:4], oid)
 
-    def open(self, oid: str, **kwargs) -> BinaryIO:
-        return open(self.oid_to_path(oid), **kwargs)
+    def open(
+        self,
+        obj: Union[Pointer, str],
+        fetch_url: Optional[str] = None,
+        **kwargs,
+    ) -> BinaryIO:
+        oid = obj if isinstance(obj, str) else obj.oid
+        path = self.oid_to_path(oid)
+        try:
+            return open(path, **kwargs)
+        except FileNotFoundError:
+            if not fetch_url or not isinstance(obj, Pointer):
+                raise
+        try:
+            self.fetch(fetch_url, [obj])
+        except BaseException as exc:
+            print("fetch interrupted")
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), path
+            ) from exc
+        return open(path, **kwargs)
+
+    def close(self):
+        pass

--- a/src/scmrepo/git/lfs/storage.py
+++ b/src/scmrepo/git/lfs/storage.py
@@ -22,6 +22,11 @@ class LFSStorage:
     def oid_to_path(self, oid: str):
         return os.path.join(self.path, "objects", oid[0:2], oid[2:4], oid)
 
+    def exists(self, obj: Union[Pointer, str]):
+        oid = obj if isinstance(obj, str) else obj.oid
+        path = self.oid_to_path(oid)
+        return os.path.exists(path)
+
     def open(
         self,
         obj: Union[Pointer, str],
@@ -38,7 +43,6 @@ class LFSStorage:
         try:
             self.fetch(fetch_url, [obj])
         except BaseException as exc:
-            print("fetch interrupted")
             raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), path
             ) from exc

--- a/src/scmrepo/git/objects.py
+++ b/src/scmrepo/git/objects.py
@@ -82,12 +82,13 @@ class GitTrie:
         key: tuple,
         mode: Optional[str] = "r",
         encoding: Optional[str] = None,
+        raw: bool = True,
     ):
         obj = self.trie[key]
         if obj.isdir:
             raise IsADirectoryError
 
-        return obj.open(mode=mode, encoding=encoding, key=key, rev=self.rev)
+        return obj.open(mode=mode, encoding=encoding, key=key, raw=raw, rev=self.rev)
 
     def exists(self, key: tuple) -> bool:
         return bool(self.trie.has_node(key))

--- a/src/scmrepo/git/objects.py
+++ b/src/scmrepo/git/objects.py
@@ -20,7 +20,7 @@ def _to_datetime(time: int, offset: int) -> datetime.datetime:
 
 class GitObject(ABC):
     @abstractmethod
-    def open(self, mode: str = "r", encoding: str = None):
+    def open(self, mode: str = "r", encoding: str = None, **kwargs):
         pass
 
     @property
@@ -87,7 +87,7 @@ class GitTrie:
         if obj.isdir:
             raise IsADirectoryError
 
-        return obj.open(mode=mode, encoding=encoding)
+        return obj.open(mode=mode, encoding=encoding, key=key, rev=self.rev)
 
     def exists(self, key: tuple) -> bool:
         return bool(self.trie.has_node(key))

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -22,19 +22,23 @@ def fixture_make_fs(scm: Git, git: Git):
     return _make_fs
 
 
-def test_open(tmp_dir: TmpDir, scm: Git, make_fs):
+@pytest.mark.parametrize("raw", [True, False])
+def test_open(tmp_dir: TmpDir, scm: Git, make_fs, raw: bool, git_backend: str):
+    if not raw and git_backend != "pygit2":
+        pytest.skip()
+
     files = tmp_dir.gen({"foo": "foo", "тест": "проверка", "data": {"lorem": "ipsum"}})
     scm.add_commit(files, message="add")
 
     fs = make_fs()
-    with fs.open("foo", mode="r", encoding="utf-8") as fobj:
+    with fs.open("foo", mode="r", encoding="utf-8", raw=raw) as fobj:
         assert fobj.read() == "foo"
-    with fs.open("тест", mode="r", encoding="utf-8") as fobj:
+    with fs.open("тест", mode="r", encoding="utf-8", raw=raw) as fobj:
         assert fobj.read() == "проверка"
     with pytest.raises(IOError):
-        fs.open("not-existing-file")
+        fs.open("not-existing-file", raw=raw)
     with pytest.raises(IOError):
-        fs.open("data")
+        fs.open("data", raw=raw)
 
 
 def test_exists(tmp_dir: TmpDir, scm: Git, make_fs):

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -1,0 +1,75 @@
+import io
+
+import pytest
+from pytest_mock import MockerFixture
+from pytest_test_utils import TempDirFactory, TmpDir
+
+from scmrepo.git import Git
+from scmrepo.git.lfs import LFSStorage, Pointer, smudge
+
+FOO_OID = "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+FOO_POINTER = (
+    f"version https://git-lfs.github.com/spec/v1\noid sha256:{FOO_OID}\nsize 3\n"
+).encode()
+
+
+@pytest.fixture
+def storage(tmp_dir_factory: TempDirFactory) -> LFSStorage:
+    storage_path = tmp_dir_factory.mktemp("lfs")
+    return LFSStorage(storage_path)
+
+
+@pytest.fixture
+def lfs(tmp_dir: TmpDir, scm: Git) -> None:
+    tmp_dir.gen(".gitattributes", "*.lfs filter=lfs diff=lfs merge=lfs -text")
+    scm.add([".gitattributes"])
+    scm.commit("init lfs attributes")
+
+
+@pytest.fixture
+def lfs_objects(tmp_dir: TmpDir) -> TmpDir:
+    objects = tmp_dir / ".git" / "lfs" / "objects"
+    objects.mkdir(parents=True)
+    return objects
+
+
+def test_pointer_build(tmp_dir: TmpDir):
+    tmp_dir.gen("foo", "foo")
+    with open(tmp_dir / "foo", "rb") as fobj:
+        pointer = Pointer.build(fobj)
+
+    assert pointer.dump() == FOO_POINTER.decode("utf-8")
+
+
+def test_pointer_load(tmp_dir: TmpDir):
+    tmp_dir.gen("foo.lfs", FOO_POINTER)
+    with open(tmp_dir / "foo.lfs", "rb") as fobj:
+        pointer = Pointer.load(fobj)
+    assert pointer.oid == FOO_OID
+    assert pointer.size == 3
+
+
+def test_smudge(tmp_dir: TmpDir, storage: LFSStorage, mocker: MockerFixture):
+    tmp_dir.gen("foo.lfs", FOO_POINTER)
+    with open(tmp_dir / "foo.lfs", "rb") as fobj:
+        assert smudge(storage, fobj).read() == FOO_POINTER
+
+    mocker.patch.object(storage, "open", return_value=io.BytesIO(b"foo"))
+    with open(tmp_dir / "foo.lfs", "rb") as fobj:
+        assert smudge(storage, fobj).read() == b"foo"
+
+
+@pytest.mark.usefixtures("lfs")
+def test_lfs(tmp_dir: TmpDir, scm: Git, lfs_objects: TmpDir):
+    # NOTE: scmrepo does not currently support LFS clean (writes), this writes
+    # the pointer to the git odb (simulating an actual LFS clean)
+    tmp_dir.gen("foo.lfs", FOO_POINTER)
+    scm.add(["foo.lfs"])
+    scm.commit("add foo")
+    lfs_objects.gen({FOO_OID[0:2]: {FOO_OID[2:4]: {FOO_OID: "foo"}}})
+
+    fs = scm.get_fs("HEAD")
+    with fs.open("foo.lfs", "rb", raw=True) as fobj:
+        assert fobj.read() == FOO_POINTER
+    with fs.open("foo.lfs", "rb", raw=False) as fobj:
+        assert fobj.read() == b"foo"

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import io
 
 import pytest


### PR DESCRIPTION
Will close https://github.com/iterative/dvc/issues/9175
Requires https://github.com/libgit2/pygit2/pull/1237

- Adds minimal read-only LFS implementation
- `lfs smudge` filtering is enabled by via libgit2/pygit2 backend filter
    - When Git checks out (or reads) a blob with the `filter=lfs` .gitattribute the LFS object will be read from local storage or fetched (per default CLI `lfs smudge` behavior)
- `lfs fetch` is implemented via `scmrepo.git.lfs.fetch` and can be used to fetch multiple LFS objects in a batch operation (so subsequent git checkout/blob read can be done from local storage)
- Minimal CLI implementation is available for some commands. This is mainly useful for compatibility testing purposes and should not be considered a complete replacement for CLI LFS, commands only implement the typical default usage flags.:
    - `python -m scmrepo.git.lfs.fetch` (`git lfs fetch`)
    - `python -m scmrepo.git.lfs.pointer` (`git lfs pointer`)
    - `python -m scmrepo.git.lfs.smudge` (`git lfs smudge`)
- [LFS configuration](https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-config.adoc) is only partially implemented. Currently supported options (`.lfsconfig` is supported in addition to Git repo config when applicable):
    - `lfs.storage`
    - `lfs.url`
    - `remote.lfsdefault`
    - `remote.*.lfsurl`
- `lfs.fetchinclude` and `lfs.fetchexclude` equivalent behavior is supported internally via `scmrepo.git.lfs.fetch(include=..., exclude=...)`, but `fetch()` will not read the configured include/exclude patterns by default).