### PR TITLE
pygit2: convert libgit2/pygit2 timezone offsets to standard git offsets

### DIFF
--- a/src/scmrepo/git/backend/pygit2/__init__.py
+++ b/src/scmrepo/git/backend/pygit2/__init__.py
@@ -401,7 +401,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         return GitCommit(
             str(commit.id),
             commit.commit_time,
-            commit.commit_time_offset,
+            commit.commit_time_offset * 60,
             commit.message,
             [str(parent) for parent in commit.parent_ids],
             commit.committer.name,
@@ -409,7 +409,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
             commit.author.name,
             commit.author.email,
             commit.author.time,
-            commit.author.offset,
+            commit.author.offset * 60,
         )
 
     def _get_stash(self, ref: str):
@@ -962,7 +962,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
                     tag.tagger.name,
                     tag.tagger.email,
                     tag.tagger.time,
-                    tag.tagger.offset,
+                    tag.tagger.offset * 60,
                     tag.message,
                 )
         except KeyError:

--- a/src/scmrepo/git/objects.py
+++ b/src/scmrepo/git/objects.py
@@ -1,3 +1,4 @@
+import datetime
 import stat
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -10,6 +11,11 @@ S_IFGITLINK = 0o160000
 
 def S_ISGITLINK(m: int) -> bool:
     return stat.S_IFMT(m) == S_IFGITLINK
+
+
+def _to_datetime(time: int, offset: int) -> datetime.datetime:
+    tz = datetime.timezone(datetime.timedelta(seconds=offset))
+    return datetime.datetime.fromtimestamp(time, tz=tz)
 
 
 class GitObject(ABC):
@@ -169,6 +175,14 @@ class GitCommit:
     author_time: int
     author_time_offset: int
 
+    @property
+    def commit_datetime(self) -> datetime.datetime:
+        return _to_datetime(self.commit_time, self.commit_time_offset)
+
+    @property
+    def author_datetime(self) -> datetime.datetime:
+        return _to_datetime(self.author_time, self.author_time_offset)
+
 
 @dataclass
 class GitTag:
@@ -180,3 +194,7 @@ class GitTag:
     tag_time: int
     tag_time_offset: int
     message: str
+
+    @property
+    def tag_datetime(self) -> datetime.datetime:
+        return _to_datetime(self.tag_time, self.tag_time_offset)


### PR DESCRIPTION
libgit2 returns tz offset in minutes from UTC but git internals (and git-python + dulwich) use seconds from UTC. Our scmrepo git objects should use seconds for consistency

see: https://github.com/iterative/gto/pull/425/files#r1350738275