### PR TITLE
Convert check_ref_format to class method

### DIFF
--- a/src/scmrepo/git/backend/base.py
+++ b/src/scmrepo/git/backend/base.py
@@ -406,8 +406,9 @@ class BaseGitBackend(ABC):
     def get_remote_url(self, remote: str) -> str:
         """Return URL for the specified remote."""
 
+    @staticmethod
     @abstractmethod
-    def check_ref_format(self, refname: str) -> bool:
+    def check_ref_format(cls, refname: str) -> bool:
         """Check if a reference name is well formed."""
 
     @abstractmethod

--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -926,7 +926,8 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             raise InvalidRemote(remote)
         return location
 
-    def check_ref_format(self, refname: str) -> bool:
+    @classmethod
+    def check_ref_format(cls, refname: str) -> bool:
         from dulwich.refs import check_ref_format
 
         return check_ref_format(refname.encode())

--- a/src/scmrepo/git/backend/gitpython.py
+++ b/src/scmrepo/git/backend/gitpython.py
@@ -731,7 +731,8 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
         except (KeyError, GitCommandError) as exc:
             raise InvalidRemote(remote) from exc
 
-    def check_ref_format(self, refname: str):
+    @classmethod
+    def check_ref_format(cls, refname: str):
         raise NotImplementedError
 
     def get_tag(self, name: str) -> Optional[Union[str, "GitTag"]]:

--- a/src/scmrepo/git/backend/pygit2/__init__.py
+++ b/src/scmrepo/git/backend/pygit2/__init__.py
@@ -35,7 +35,6 @@ from scmrepo.utils import relpath
 
 logger = logging.getLogger(__name__)
 
-
 if TYPE_CHECKING:
     from pygit2 import Oid, Signature
     from pygit2.config import Config as _Pygit2Config
@@ -1019,7 +1018,8 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         except KeyError as exc:
             raise InvalidRemote(remote) from exc
 
-    def check_ref_format(self, refname: str):
+    @classmethod
+    def check_ref_format(cls, refname: str):
         raise NotImplementedError
 
     def get_tag(self, name: str) -> Optional[Union[str, "GitTag"]]:


### PR DESCRIPTION
Refactored the check_ref_format function in dulwich/__init__.py to a class method for more flexibility and to allow calling it without instantiating the class. This simplifies the usage of this method while maintaining existing functionality.

More context for this is at https://github.com/iterative/studio/pull/8187#issuecomment-1804589654