### PR TITLE
lfs: default to basic transfer API

### DIFF
--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -196,7 +196,7 @@ class LFSClient(AbstractContextManager):
                     callback.relative_update()
 
         resp_data = await self._batch_request(objects, **kwargs)
-        if resp_data.get("transfer") != "basic":
+        if resp_data.get("transfer", "basic") != "basic":
             raise LFSError("Unsupported LFS transfer type")
         coros = []
         for data in resp_data.get("objects", []):


### PR DESCRIPTION
I've fixed the download of LFS objects when the [Batch API](https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md) response does not contain a `transfer` property. In this case, the `transfer` property should default to `"basic"`. This [behavior conforms with the spec](https://github.com/git-lfs/git-lfs/blob/ad64c6cf4e40688ba64e2026e5eb21b845a288b1/docs/api/basic-transfers.md?plain=1#L7-L9):

> All Git LFS clients and servers SHOULD support it, and default to it if the [Batch API](https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md) request or response do not specify a `transfer` property.

For instance, GitLab's LFS server does not provide the `transfer` property, which causes `scmrepo` to fail with:

```
.../scmrepo/git/lfs/client.py", line 201, in _download
    raise LFSError("Unsupported LFS transfer type")
```

After this fix, downloading LFS objects from GitLab works.