### PR TITLE
lfs: remove unused `_LFSClient` class

### DIFF
--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -25,11 +25,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class _LFSClient(ReadOnlyRetryClient):
-    async def _request(self, *args, **kwargs):
-        return await super()._request(*args, **kwargs)  # pylint: disable=no-member
-
-
 # pylint: disable=abstract-method
 class _LFSFileSystem(HTTPFileSystem):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Some minor cleanup: I've removed the [unused](https://github.com/search?q=repo%3Aiterative%2Fscmrepo%20%22_LFSClient%22&type=code) `_LFSClient` class.