### PR TITLE
lfs: remove obsolete class constructor

### DIFF
--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -27,9 +27,6 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=abstract-method
 class _LFSFileSystem(HTTPFileSystem):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def _prepare_credentials(self, **config):
         return {}
 


### PR DESCRIPTION
Just some minor cleanup: I've removed the obsolete class constructor of `_LFSFileSystem`. It simply calls the parent class constructor and passes all arguments through, so there's no need to have it.