### PR TITLE
lfs: add missing `Accept` header to Batch API request

### DIFF
--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -167,6 +167,7 @@ class LFSClient(AbstractContextManager):
             body["ref"] = [{"name": ref}]
         session = await self._set_session()
         headers = dict(self.headers)
+        headers["Accept"] = self.JSON_CONTENT_TYPE
         headers["Content-Type"] = self.JSON_CONTENT_TYPE
         async with session.post(
             url,


### PR DESCRIPTION
I've fixed the Batch API request header to include `Accept: application/vnd.git-lfs+json` as stated in the [spec](https://github.com/git-lfs/git-lfs/blob/b4a0927e399ed4acfa838b0c3c17011dce1658ae/docs/api/batch.md#L19):

> All Batch API requests use the POST verb, and require the following HTTP headers. The request and response bodies are JSON.
>
> ```
> Accept: application/vnd.git-lfs+json
> Content-Type: application/vnd.git-lfs+json
> ```

For instance, omitting this header leads to an error when fetching LFS objects from github.com:

```console
$ dvc import https://github.com/githubschool/lfs-example TogglDesktop-7_4_373.dmg
Importing 'TogglDesktop-7_4_373.dmg (https://github.com/githubschool/lfs-example)' -> 'TogglDesktop-7_4_373.dmg'
...
Could not open LFS object, falling back to raw pointer
...
```

github.com responds to the Batch API request with HTTP status code 406 and the following response body:

```json
{"message":"Not Acceptable","documentation_url":"https://support.github.com/contact"}
```

When the `Accept` header is included, it works fine.