### PR TITLE
lfs: use `HTTPFileSystem` from `fsspec` instead of `dvc-http`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "funcy>=1.14",
     "shortuuid>=0.5.0",
     "dvc-objects>=4,<5",
-    "dvc-http>=2.29.0",
+    "aiohttp-retry>=2.5.0",
 ]
 
 [project.urls]
@@ -109,7 +109,6 @@ files = ["src", "tests"]
 [[tool.mypy.overrides]]
 module = [
     "pygtrie",
-    "dvc_http.*",
     "funcy",
     "git",
     "gitdb.*",


### PR DESCRIPTION
I've refactored the `LFSClient` class some more to directly use `fsspec`'s `HTTPFileSystem` implementation instead of the one from `dvc-http`, as most of `dvc-http`'s implementation is irrelevant to making HTTP requests independent of DVC. I've retained the retry client, which `dvc-http` also uses, because that's generally consistent with the official Git LFS client's implementation. In fact, the [official Git LFS client also supports retries for Batch API requests](https://github.com/git-lfs/git-lfs/blob/82f58ad228ff49abb31618152b1992820bb84f5e/tq/api.go#L94), which are disabled by `dvc-http`'s `ReadOnlyRetryClient` class. To otherwise keep the retry behavior as before, I've [copied the retry settings from `dvc-http`](https://github.com/iterative/dvc-http/blob/1df9de067248c9408b5e8b24c53c3f6998dd141c/dvc_http/__init__.py#L42-L44) including the [hardcoded number of parallel jobs inherited from `dvc_objects.fs.base.FileSystem`](https://github.com/iterative/dvc-objects/blob/76eed478b0351dab5c0c150e23cad6ff41e47b57/src/dvc_objects/fs/base.py#L75). In a follow-up PR, I believe we should make this value configurable and get the `jobs` value from DVC's used `FileSystem` instance in [`dvc.scm.lfs_prefetch`](https://github.com/iterative/dvc/blob/196c1c7a17d15e50be5da359599c7e51059cec30/dvc/scm.py#L269-L293) like this:

```diff
 def lfs_prefetch(fs: "FileSystem", paths: List[str]):
     from scmrepo.git.lfs import fetch as _lfs_fetch

     from dvc.fs.dvc import DVCFileSystem
     from dvc.fs.git import GitFileSystem

     if isinstance(fs, DVCFileSystem) and isinstance(fs.repo.fs, GitFileSystem):
         git_fs = fs.repo.fs
         scm = fs.repo.scm
         assert isinstance(scm, Git)
     else:
         return

     try:
         if "filter=lfs" not in git_fs.open(".gitattributes").read():
             return
     except OSError:
         return
     with TqdmGit(desc="Checking for Git-LFS objects") as pbar:
         _lfs_fetch(
             scm,
             [git_fs.rev],
             include=[(path if path.startswith("/") else f"/{path}") for path in paths],
             progress=pbar.update_git,
+            jobs=fs.jobs,
         )
```