### PR TITLE
lfs: drop dvc objects dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,12 @@ dependencies = [
     "dulwich>=0.21.6",
     "pygit2>=1.14.0",
     "pygtrie>=2.3.2",
-    "fsspec>=2024.2.0",
+    "fsspec[tqdm]>=2024.2.0",
     "pathspec>=0.9.0",
     "asyncssh>=2.13.1,<3",
     "funcy>=1.14",
-    "shortuuid>=0.5.0",
-    "dvc-objects>=4,<5",
     "aiohttp-retry>=2.5.0",
+    "tqdm",
 ]
 
 [project.urls]
@@ -54,6 +53,7 @@ tests = [
     "types-certifi==2021.10.8.3",
     "types-mock==5.1.0.2",
     "types-paramiko==3.4.0.20240120",
+    "types-tqdm",
 ]
 dev = [
     "scmrepo[tests]",

--- a/src/scmrepo/git/lfs/progress.py
+++ b/src/scmrepo/git/lfs/progress.py
@@ -1,9 +1,112 @@
-from typing import BinaryIO, Callable, Optional, Union
+import logging
+import sys
+from typing import Any, BinaryIO, Callable, ClassVar, Optional, Union
 
-from dvc_objects.fs.callbacks import TqdmCallback
-from fsspec.callbacks import DEFAULT_CALLBACK, Callback
+from fsspec.callbacks import DEFAULT_CALLBACK, Callback, TqdmCallback
+from tqdm import tqdm
 
 from scmrepo.progress import GitProgressEvent
+
+
+class _Tqdm(tqdm):
+    """
+    maximum-compatibility tqdm-based progressbars
+    """
+
+    BAR_FMT_DEFAULT = (
+        "{percentage:3.0f}% {desc}|{bar}|"
+        "{postfix[info]}{n_fmt}/{total_fmt}"
+        " [{elapsed}<{remaining}, {rate_fmt:>11}]"
+    )
+    # nested bars should have fixed bar widths to align nicely
+    BAR_FMT_DEFAULT_NESTED = (
+        "{percentage:3.0f}%|{bar:10}|{desc:{ncols_desc}.{ncols_desc}}"
+        "{postfix[info]}{n_fmt}/{total_fmt}"
+        " [{elapsed}<{remaining}, {rate_fmt:>11}]"
+    )
+    BAR_FMT_NOTOTAL = "{desc}{bar:b}|{postfix[info]}{n_fmt} [{elapsed}, {rate_fmt:>11}]"
+    BYTES_DEFAULTS: ClassVar[dict[str, Any]] = {
+        "unit": "B",
+        "unit_scale": True,
+        "unit_divisor": 1024,
+        "miniters": 1,
+    }
+
+    def __init__(  # noqa: PLR0913
+        self,
+        iterable=None,
+        disable=None,
+        level=logging.ERROR,
+        desc=None,
+        leave=False,
+        bar_format=None,
+        bytes=False,  # noqa: A002
+        file=None,
+        total=None,
+        postfix=None,
+        **kwargs,
+    ):
+        kwargs = kwargs.copy()
+        if bytes:
+            kwargs = {**self.BYTES_DEFAULTS, **kwargs}
+        else:
+            kwargs.setdefault("unit_scale", total > 999 if total else True)
+        if file is None:
+            file = sys.stderr
+        super().__init__(
+            iterable=iterable,
+            disable=disable,
+            leave=leave,
+            desc=desc,
+            bar_format="!",
+            lock_args=(False,),
+            total=total,
+            **kwargs,
+        )
+        self.postfix = postfix or {"info": ""}
+        if bar_format is None:
+            if self.__len__():
+                self.bar_format = (
+                    self.BAR_FMT_DEFAULT_NESTED if self.pos else self.BAR_FMT_DEFAULT
+                )
+            else:
+                self.bar_format = self.BAR_FMT_NOTOTAL
+        else:
+            self.bar_format = bar_format
+        self.refresh()
+
+    def update_to(self, current, total=None):
+        if total:
+            self.total = total
+        self.update(current - self.n)
+
+    def close(self):
+        self.postfix["info"] = ""
+        # remove ETA (either unknown or zero); remove completed bar
+        self.bar_format = self.bar_format.replace("<{remaining}", "").replace(
+            "|{bar:10}|", " "
+        )
+        super().close()
+
+    @property
+    def format_dict(self):
+        """inject `ncols_desc` to fill the display width (`ncols`)"""
+        d = super().format_dict
+        ncols = d["ncols"] or 80
+        # assumes `bar_format` has max one of ("ncols_desc" & "ncols_info")
+
+        meter = self.format_meter(  # type: ignore[call-arg]
+            ncols_desc=1, ncols_info=1, **d
+        )
+        ncols_left = ncols - len(meter) + 1
+        ncols_left = max(ncols_left, 0)
+        if ncols_left:
+            d["ncols_desc"] = d["ncols_info"] = ncols_left
+        else:
+            # work-around for zero-width description
+            d["ncols_desc"] = d["ncols_info"] = 1
+            d["prefix"] = ""
+        return d
 
 
 class LFSCallback(Callback):
@@ -37,7 +140,11 @@ class LFSCallback(Callback):
     def branched(self, path_1: Union[str, BinaryIO], path_2: str, **kwargs):
         if self.git_progress:
             return TqdmCallback(
-                bytes=True, desc=path_1 if isinstance(path_1, str) else path_2
+                tqdm_kwargs={
+                    "desc": path_1 if isinstance(path_1, str) else path_2,
+                    "bytes": True,
+                },
+                tqdm_cls=_Tqdm,
             )
         return DEFAULT_CALLBACK
 

--- a/src/scmrepo/git/lfs/smudge.py
+++ b/src/scmrepo/git/lfs/smudge.py
@@ -11,7 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 def smudge(
-    storage: "LFSStorage", fobj: BinaryIO, url: Optional[str] = None
+    storage: "LFSStorage",
+    fobj: BinaryIO,
+    url: Optional[str] = None,
+    batch_size: Optional[int] = None,
 ) -> BinaryIO:
     """Wrap the specified binary IO stream and run LFS smudge if necessary."""
     reader = io.BufferedReader(fobj)  # type: ignore[arg-type]


### PR DESCRIPTION
- Drops dvc-objects usage in favor of fsspec equivalents
- Drops DVC jobs/_JOBS usage in favor of exposing fsspec batch_size (see https://github.com/iterative/scmrepo/pull/315#issuecomment-1928855658)