### PR TITLE
chore(deps): cleanup and bump pytest docker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,7 @@ tests = [
     "mypy==0.971",
     "pytest-test-utils==0.0.8",
     "pytest-asyncio==0.18.3",
-    # https://github.com/docker/docker-py/issues/2902
-    "pytest-docker==2.2.0; python_version < '3.10' and implementation_name != 'pypy'",
+    "pytest-docker==3.1.1",
     "mock==5.1.0",
     "paramiko==3.4.0",
     "types-certifi==2021.10.8.3",


### PR DESCRIPTION
Hopefully that workaround is not needed anymore and we could use it on all Python versions