### PR TITLE
support scp-style shorthand urls with users other than git@

### DIFF
--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -235,7 +235,7 @@ class _SSHLFSClient(LFSClient):
     def from_git_url(cls, git_url: str) -> "_SSHLFSClient":
         if scp_match := SCP_REGEX.match(git_url):
             # Add an ssh:// prefix and replace the ':' with a '/'.
-            git_url = scp_match.expand("ssh://\1\2/\3")
+            git_url = scp_match.expand(r"ssh://\1\2/\3")
 
         parsed = urlparse(git_url)
         if parsed.scheme != "ssh" or not parsed.hostname:

--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -242,11 +242,13 @@ class _SSHLFSClient(LFSClient):
             raise ValueError(f"Invalid Git SSH URL: {git_url}")
 
         host = parsed.hostname
+        port = parsed.port or 22
         path = parsed.path.lstrip("/")
         username = parsed.username
-        port = parsed.port
-        url = f"https://{host}/{path}/info/lfs"
-        return cls(url, host, port or 22, username, path)
+
+        url_path = path.removesuffix(".git") + ".git/info/lfs"
+        url = f"https://{host}/{url_path}"
+        return cls(url, host, port, username, path)
 
     def _get_auth_header(self, *, upload: bool) -> dict:
         return self._git_lfs_authenticate(

--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -245,7 +245,7 @@ class _SSHLFSClient(LFSClient):
         path = parsed.path.lstrip("/")
         username = parsed.username
         port = parsed.port
-        url = f"https://{host}/{path}.git/info/lfs"
+        url = f"https://{host}/{path}/info/lfs"
         return cls(url, host, port or 22, username, path)
 
     def _get_auth_header(self, *, upload: bool) -> dict:

--- a/src/scmrepo/git/lfs/client.py
+++ b/src/scmrepo/git/lfs/client.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import re
 import shutil
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator
@@ -10,6 +9,7 @@ from http import HTTPStatus
 from tempfile import NamedTemporaryFile
 from time import time
 from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import urlparse
 
 import aiohttp
 from aiohttp_retry import ExponentialRetry, RetryClient
@@ -20,6 +20,7 @@ from funcy import cached_property
 
 from scmrepo.git.backend.dulwich import _get_ssh_vendor
 from scmrepo.git.credentials import Credential, CredentialNotFoundError
+from scmrepo.urls import SCP_REGEX, is_scp_style_url
 
 from .exceptions import LFSError
 from .pointer import Pointer
@@ -84,7 +85,7 @@ class LFSClient(AbstractContextManager):
 
     @classmethod
     def from_git_url(cls, git_url: str) -> "LFSClient":
-        if git_url.startswith(("ssh://", "git@")):
+        if git_url.startswith("ssh://") or is_scp_style_url(git_url):
             return _SSHLFSClient.from_git_url(git_url)
         if git_url.startswith(("http://", "https://")):
             return _HTTPLFSClient.from_git_url(git_url)
@@ -213,11 +214,9 @@ class _HTTPLFSClient(LFSClient):
 
 
 class _SSHLFSClient(LFSClient):
-    _URL_PATTERN = re.compile(
-        r"(?:ssh://)?git@(?P<host>\S+?)(?::(?P<port>\d+))?(?:[:/])(?P<path>\S+?)\.git"
-    )
-
-    def __init__(self, url: str, host: str, port: int, path: str):
+    def __init__(
+        self, url: str, host: str, port: int, username: Optional[str], path: str
+    ):
         """
         Args:
             url: LFS server URL.
@@ -228,25 +227,40 @@ class _SSHLFSClient(LFSClient):
         super().__init__(url)
         self.host = host
         self.port = port
+        self.username = username
         self.path = path
         self._ssh = _get_ssh_vendor()
 
     @classmethod
     def from_git_url(cls, git_url: str) -> "_SSHLFSClient":
-        result = cls._URL_PATTERN.match(git_url)
-        if not result:
+        if scp_match := SCP_REGEX.match(git_url):
+            # Add an ssh:// prefix and replace the ':' with a '/'.
+            git_url = scp_match.expand("ssh://\1\2/\3")
+
+        parsed = urlparse(git_url)
+        if parsed.scheme != "ssh" or not parsed.hostname:
             raise ValueError(f"Invalid Git SSH URL: {git_url}")
-        host, port, path = result.group("host", "port", "path")
+
+        host = parsed.hostname
+        path = parsed.path.lstrip("/")
+        username = parsed.username
+        port = parsed.port
         url = f"https://{host}/{path}.git/info/lfs"
-        return cls(url, host, int(port or 22), path)
+        return cls(url, host, port or 22, username, path)
 
     def _get_auth_header(self, *, upload: bool) -> dict:
         return self._git_lfs_authenticate(
-            self.host, self.port, f"{self.path}.git", upload=upload
+            self.host, self.port, self.username, self.path, upload=upload
         ).get("header", {})
 
     def _git_lfs_authenticate(
-        self, host: str, port: int, path: str, *, upload: bool = False
+        self,
+        host: str,
+        port: int,
+        username: Optional[str],
+        path: str,
+        *,
+        upload: bool = False,
     ) -> dict:
         action = "upload" if upload else "download"
         return json.loads(
@@ -254,7 +268,7 @@ class _SSHLFSClient(LFSClient):
                 command=f"git-lfs-authenticate {path} {action}",
                 host=host,
                 port=port,
-                username="git",
+                username=username,
             ).read()
         )
 

--- a/src/scmrepo/urls.py
+++ b/src/scmrepo/urls.py
@@ -1,0 +1,21 @@
+import re
+
+# from https://github.com/pypa/pip/blob/303fed36c1771de4063063a866776a9103972317/src/pip/_internal/vcs/git.py#L40
+# SCP (Secure copy protocol) shorthand. e.g. 'git@example.com:foo/bar.git'
+SCP_REGEX = re.compile(
+    r"""^
+    # Optional user, e.g. 'git@'
+    (\w+@)?
+    # Server, e.g. 'github.com'.
+    ([^/:]+):
+    # The server-side path. e.g. 'user/project.git'. Must start with an
+    # alphanumeric character so as not to be confusable with a Windows paths
+    # like 'C:/foo/bar' or 'C:\foo\bar'.
+    (\w[^:]*)
+    $""",
+    re.VERBOSE,
+)
+
+
+def is_scp_style_url(url: str) -> bool:
+    return bool(SCP_REGEX.match(url))

--- a/tests/test_pygit2.py
+++ b/tests/test_pygit2.py
@@ -68,6 +68,8 @@ def test_pygit_stash_apply_conflicts(
     "url",
     [
         "git@github.com:iterative/scmrepo.git",
+        "github.com:iterative/scmrepo.git",
+        "user@github.com:iterative/scmrepo.git",
         "ssh://login@server.com:12345/repository.git",
     ],
 )

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,31 @@
+import pytest
+
+from scmrepo.urls import is_scp_style_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "git@github.com:iterative/scmrepo.git",
+        "github.com:iterative/scmrepo.git",
+        "user@github.com:iterative/scmrepo.git",
+    ],
+)
+def test_scp_url(url: str):
+    assert is_scp_style_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        r"C:\foo\bar",
+        "C:/foo/bar",
+        "/home/user/iterative/scmrepo/git",
+        "~/iterative/scmrepo/git",
+        "ssh://login@server.com:12345/repository.git",
+        "https://user:password@github.com/iterative/scmrepo.git",
+        "https://github.com/iterative/scmrepo.git",
+    ],
+)
+def test_scp_url_invalid(url: str):
+    assert not is_scp_style_url(url)


### PR DESCRIPTION
See discussion: https://discuss.dvc.org/t/dvc-import-fails-with-git-failed-to-fetch-ref-from/1997

scp shorthand URL format is as follows:
```console
[user@]host.domain.com:path/to/resource
```

So, `user` can be anything, and is optional. 


> [!NOTE]
> Does not work with absolute paths in scp-style URLs, eg: `git@github.com:/path/to/resource`.
