### PR TITLE
lfs: optimize path filtering

### DIFF
--- a/src/scmrepo/git/lfs/fetch.py
+++ b/src/scmrepo/git/lfs/fetch.py
@@ -1,6 +1,7 @@
 import fnmatch
 import io
 import os
+import re
 from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Callable, Optional
 
@@ -98,6 +99,9 @@ def get_fetch_url(scm: "Git", remote: Optional[str] = None):  # noqa: C901,PLR09
     return scm.get_remote_url(remote)
 
 
+_ROOT_PATH_PREFIX_REGEX = re.compile(r"^(?P<prefix>[^*?\[]*(?:/|$))")
+
+
 def _collect_objects(
     scm: "Git",
     rev: str,
@@ -105,7 +109,25 @@ def _collect_objects(
     exclude: Optional[list[str]],
 ) -> Iterator[Pointer]:
     fs = scm.get_fs(rev)
-    for path in _filter_paths(fs.find("/"), include, exclude):
+    # Optimize path filtering if the `include` list contains exactly one path.
+    # First, determine the root directory wherein to initiate the file search.
+    # If the `include` path is a Unix filename pattern, determine the static
+    # path prefix and set it as the root directory. Second, if the path and the
+    # root are identical or the Unix filename pattern matches *any* (i.e., `**`)
+    # file under the root directory, unset `include` to avoid unnecessary
+    # filtering work.
+    if (
+        include
+        and len(include) == 1
+        and (result := _ROOT_PATH_PREFIX_REGEX.match(path := include[0]))
+    ):
+        root = result.group("prefix")
+        if path in {root, f'{root.rstrip("/")}/**'}:
+            include = []
+    else:
+        root = "/"
+
+    for path in _filter_paths(fs.find(root), include, exclude):
         check_path = path.lstrip("/")
         if scm.check_attr(check_path, "filter", source=rev) == "lfs":
             try:


### PR DESCRIPTION
I've optimized LFS path filtering as we discussed in #338. The first optimization implements the suggestion in https://github.com/iterative/scmrepo/issues/338#issuecomment-2081256097 to short-cut a single-path `include` filter. Here are the tests for the regex that extracts the path prefix: https://regex101.com/r/wBjHf0/1 Note that the extra `\n` on regex101.com is only necessary to allow one test case per line, it isn't needed in the actual regex. ~~The second optimization unionizes the filename regex patterns derived from Unix filename patterns and matches each path against the pre-compiled single regex, which is faster than matching against the Unix filename patterns individually. Also, it avoids intermediate list materialization but instead implements a streaming filter.~~

~~As the two commits implement independent optimizations, I intend this PR to be rebase-merged without commit squashing.~~

Partially fixes #338.