### PR TITLE
lfs: optimize Unix filename pattern path filtering

### DIFF
--- a/src/scmrepo/git/lfs/fetch.py
+++ b/src/scmrepo/git/lfs/fetch.py
@@ -143,16 +143,13 @@ def _collect_objects(
 def _filter_paths(
     paths: Iterable[str], include: Optional[list[str]], exclude: Optional[list[str]]
 ) -> Iterator[str]:
-    filtered = set()
     if include:
-        for pattern in include:
-            filtered.update(fnmatch.filter(paths, pattern))
-    else:
-        filtered.update(paths)
+        include_match = re.compile(r"|".join(map(fnmatch.translate, include))).match
+        paths = (path for path in paths if include_match(path) is not None)
     if exclude:
-        for pattern in exclude:
-            filtered.difference_update(fnmatch.filter(paths, pattern))
-    yield from filtered
+        exclude_match = re.compile(r"|".join(map(fnmatch.translate, exclude))).match
+        paths = (path for path in paths if exclude_match(path) is None)
+    yield from paths
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've optimized the path filtering utility function [`scmrepo.git.lfs.fetch._filter_paths()`](https://github.com/iterative/scmrepo/blob/a99a943a6dffa7e7196ab85d7e70e93531495e2c/src/scmrepo/git/lfs/fetch.py#L121-L133) by unionizing the filename regex patterns derived from Unix filename patterns, so it matches each path against the pre-compiled single regex, which is faster than matching against the Unix filename patterns individually. Also, it avoids intermediate list materialization but instead implements a streaming filter.

Partially fixes #338.