### PR TITLE
drop safety

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,12 +40,11 @@ jobs:
         pip --version
         nox --version
 
-    - name: Lint code and check dependencies
-      continue-on-error: ${{ matrix.nox_pyv == '3.11' }}
-      run: nox -s lint safety --verbose
+    - name: Lint code
+      run: nox -s lint
 
     - name: Run tests
-      run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }} -- --slow --cov-report=xml
+      run: nox -s tests-${{ matrix.pyv }} -- --slow --cov-report=xml
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v3.1.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -33,14 +33,6 @@ def lint(session: nox.Session) -> None:
 
 
 @nox.session
-def safety(session: nox.Session) -> None:
-    """Scan dependencies for insecure packages."""
-    session.install(".[dev]")
-    session.install("safety")
-    session.run("safety", "check", "--full-report", "--ignore=67599")
-
-
-@nox.session
 def build(session: nox.Session) -> None:
     session.install("build", "setuptools", "twine")
     session.run("python", "-m", "build")


### PR DESCRIPTION
GitHub has dependency alerts and dependency security updates that can replace `safety`.

For the past few months, safety has been raising vulnerability errors for `pip` and now `jinja2`. The latter is a dependency of `safety` itself, and both CVEs are disputed.

Which is breaking CI for us.