### PR TITLE
dulwich: do not add files from submodules

### DIFF
--- a/src/scmrepo/base.py
+++ b/src/scmrepo/base.py
@@ -103,3 +103,7 @@ class Base(AbstractContextManager):
 
     def _reset(self) -> None:
         pass
+
+    def list_submodules(self) -> list[str]:
+        """Returns a list of submodules in the repo."""
+        return []

--- a/src/scmrepo/git/__init__.py
+++ b/src/scmrepo/git/__init__.py
@@ -412,6 +412,7 @@ class Git(Base):
     check_attr = partialmethod(_backend_func, "check_attr")
 
     get_tree_obj = partialmethod(_backend_func, "get_tree_obj")
+    list_submodules = partialmethod(_backend_func, "list_submodules")
 
     def branch_revs(self, branch: str, end_rev: Optional[str] = None) -> Iterable[str]:
         """Iterate over revisions in a given branch (from newest to oldest).

--- a/src/scmrepo/git/backend/dulwich/__init__.py
+++ b/src/scmrepo/git/backend/dulwich/__init__.py
@@ -199,6 +199,9 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         self._submodules: dict[str, str] = self._find_submodules()
         self._stashes: dict = {}
 
+    def list_submodules(self) -> list[str]:
+        raise NotImplementedError
+
     def _find_submodules(self) -> dict[str, str]:
         """Return dict mapping submodule names to submodule paths.
 
@@ -349,21 +352,6 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
     def _expand_paths(self, paths: list[str], force: bool = False) -> Iterator[str]:
         for path in paths:
-            if not os.path.isabs(path) and self._submodules:
-                # NOTE: If path is inside a submodule, Dulwich expects the
-                # staged paths to be relative to the submodule root (not the
-                # parent git repo root). We append path to root_dir here so
-                # that the result of relpath(path, root_dir) is actually the
-                # path relative to the submodule root.
-                fs_path = relpath(path, self.root_dir)
-                for sm_path in self._submodules.values():
-                    assert self.root_dir
-                    if fs_path.startswith(sm_path):
-                        path = os.path.join(
-                            self.root_dir,
-                            relpath(fs_path, sm_path),
-                        )
-                        break
             if os.path.isdir(path):
                 for root, _, fs in os.walk(path):
                     for fpath in fs:

--- a/src/scmrepo/git/backend/gitpython.py
+++ b/src/scmrepo/git/backend/gitpython.py
@@ -789,3 +789,6 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
         if info == "unset":
             return False
         return info
+
+    def list_submodules(self) -> list[str]:
+        raise NotImplementedError

--- a/src/scmrepo/git/backend/pygit2/__init__.py
+++ b/src/scmrepo/git/backend/pygit2/__init__.py
@@ -269,6 +269,9 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         # can be reacquired later as needed.
         self.repo.free()
 
+    def list_submodules(self) -> list[str]:
+        return self.repo.listall_submodules()
+
     @classmethod
     def clone(
         cls,
@@ -864,6 +867,11 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
     def reset(self, hard: bool = False, paths: Optional[Iterable[str]] = None):
         from pygit2 import IndexEntry
         from pygit2.enums import ResetMode
+
+        if self.list_submodules():
+            raise NotImplementedError(
+                "pygit2 seems to remove files from submodules on reset"
+            )
 
         self.repo.index.read(False)  # type: ignore[attr-defined]
         if paths is not None:


### PR DESCRIPTION
`git` doesn't add files from submodules when staging, so we align `dulwich` with that behavior.

Also, `libgit2`/`pygit2` removes files from submodules on `reset()`, so raise `NotImplementedError` for now to avoid accidental deletions, and redirect such cases to the `GitPython` backend instead.

Fixes https://github.com/iterative/dvc/issues/10823.